### PR TITLE
Moving Pictures time, weather and movies icon disappear on details

### DIFF
--- a/Common/movingpictures.xml
+++ b/Common/movingpictures.xml
@@ -1,0 +1,172 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<!--
+This file should contain the facade view and all gui
+elements that should remain on screen during all or
+multiple view modes.
+-->
+<window>
+  <id>96742</id>
+  <defaultcontrol>50</defaultcontrol>
+  <allowoverlay>no</allowoverlay>
+  <define>#header.label:#MovingPictures.Translation.Movies.Label</define>
+  <!--
+  This set of defines are read by the plug-in and used to determine aspects of it's behavior. These
+  are parameters to give the skinner a tiny bit more control over the presentation.
+-->
+  <define>#largeicons.available:true</define>
+  <define>#largeicons.backdrop.used:true</define>
+  <define>#smallicons.available:true</define>
+  <define>#smallicons.backdrop.used:true</define>
+  <define>#list.available:true</define>
+  <define>#list.backdrop.used:true</define>
+  <define>#filmstrip.available:true</define>
+  <define>#filmstrip.backdrop.used:true</define>
+  <define>#details.available:true</define>
+  <define>#details.backdrop.used:true</define>
+  <define>#categories.backdrop.used:true</define>
+  <define>#coverflow.available:true</define>
+  <define>#coverflow.backdrop.used:true</define>
+  <controls>
+    <!--            :: DUMMY CONTROLS ::             -->
+    <include condition="#(not(eq(#skin.layout.movingpictures.details,'lite')))">movingpictures.dummy.xml</include>
+    <include condition="#(eq(#skin.layout.movingpictures.details,'lite'))">movingpictures.dummy.lite.xml</include>
+    <!--            :: MOVIE BACKDROP ::            -->
+    <control>
+      <description>DEFAULT BACKGROUND</description>
+      <type>image</type>
+      <id>0</id>
+      <posX>0</posX>
+      <posY>0</posY>
+      <width>1920</width>
+      <height>1080</height>
+      <texture>background.png</texture>
+      <shouldCache>true</shouldCache>
+    </control>
+    <control>
+      <description>Movie Backdrop (Fan Art) - Plug-in sets to invisible, if no art.</description>
+      <type>image</type>
+      <id>1</id>
+      <posX>0</posX>
+      <posY>0</posY>
+      <width>1920</width>
+      <height>1080</height>
+      <texture>#MovingPictures.Backdrop</texture>
+      <animation effect="fade" time="300">visible</animation>
+      <animation effect="fade" time="300" delay="300">hidden</animation>
+      <animation effect="fade" time="250">WindowOpen</animation>
+      <animation effect="fade" time="250">WindowClose</animation>
+    </control>
+    <control>
+      <description>Alternate Movie Backdrop - Toggles Load with Component 1 for animations on visibiltiy</description>
+      <type>image</type>
+      <id>11</id>
+      <posX>0</posX>
+      <posY>0</posY>
+      <width>1920</width>
+      <height>1080</height>
+      <texture>#MovingPictures.Backdrop2</texture>
+      <animation effect="fade" time="300">visible</animation>
+      <animation effect="fade" time="300" delay="300">hidden</animation>
+      <animation effect="fade" time="250">WindowOpen</animation>
+      <animation effect="fade" time="250">WindowClose</animation>
+    </control>
+    <!--            :: CATEGORY VIEW ::            -->
+    <control>
+      <description>background listview</description>
+      <type>image</type>
+      <id>0</id>
+      <posX>0</posX>
+      <posY>0</posY>
+      <width>1920</width>
+      <height>273</height>
+      <texture>fanart_overlay_top.png</texture>
+      <visible>Control.IsVisible(51)</visible>
+      <animation effect="fade" time="250">WindowOpen</animation>
+      <animation effect="fade" time="250">WindowClose</animation>
+    </control>
+    <control>
+      <id>0</id>
+      <type>image</type>
+      <posX>1123</posX>
+      <posY>252</posY>
+      <width>790</width>
+      <height>790</height>
+      <texture>panel_myfilms_menu.png</texture>
+      <visible>Control.IsVisible(51)</visible>
+      <animation effect="fade" time="250">WindowOpen</animation>
+      <animation effect="fade" time="250">WindowClose</animation>
+    </control>
+    <control Style="smallTitle">
+      <description>Selected item Label</description>
+      <type>fadelabel</type>
+      <id>1</id>
+      <posX>1220</posX>
+      <posY>998</posY>
+      <align>left</align>
+      <label>#selecteditem</label>
+      <visible>Control.IsVisible(51)</visible>
+      <animation effect="fade" time="250">WindowOpen</animation>
+      <animation effect="fade" time="250">WindowClose</animation>
+    </control>
+    <!--            :: IMPORT ::            -->
+    <!--Background-->
+    <include condition="#(eq(#skin.layout.movingpictures.thumbview,'default'))">movingpictures.background.xml</include>
+    <include condition="#(eq(#skin.layout.movingpictures.thumbview,'without info'))">movingpictures.background.thumbs.noinfo.xml</include>
+    <include condition="#(eq(#skin.layout.movingpictures.thumbview,'XL'))">movingpictures.background.thumbs.XL.xml</include>
+    <control>
+      <id>0</id>
+      <type>image</type>
+      <posX>60</posX>
+      <posY>34</posY>
+      <width>68</width>
+      <height>60</height>
+      <texture>icon_movies.png</texture>
+      <visible>!Control.HasFocus(10005)</visible>
+      <animation effect="fade" time="250">WindowOpen</animation>
+      <animation effect="fade" time="250">WindowClose</animation>
+    </control>
+    <control>
+      <description>DUMMY Visible Control common.time override</description>
+      <type>label</type>
+      <id>3338333</id>
+      <posX>0</posX>
+      <posY>0</posY>
+      <width>1</width>
+      <visible>!Control.HasFocus(10005)</visible>
+    </control>
+
+    <import>common.time.xml</import>
+    <import>movingpictures.hiddenmenu.xml</import>
+    <!--Views-->
+    <include condition="#(eq(#skin.layout.movingpictures.thumbview,'default'))">movingpictures.views.xml</include>
+    <include condition="#(eq(#skin.layout.movingpictures.thumbview,'without info'))">movingpictures.views.thumbs.noinfo.xml</include>
+    <include condition="#(eq(#skin.layout.movingpictures.thumbview,'XL'))">movingpictures.views.thumbs.noinfo.xml</include>
+    <!--facade-->
+    <include condition="#(eq(#skin.layout.movingpictures.thumbview,'default'))">movingpictures.facade.xml</include>
+    <include condition="#(eq(#skin.layout.movingpictures.thumbview,'without info'))">movingpictures.facade.thumbs.noinfo.xml</include>
+    <include condition="#(eq(#skin.layout.movingpictures.thumbview,'XL'))">movingpictures.facade.thumbs.XL.xml</include>
+
+    <import>movingpictures.mediainfo.xml</import>
+
+    <!--Details-->
+    <include condition="#(not(eq(#skin.layout.movingpictures.details,'lite')))">movingpictures.details.xml</include>
+    <include condition="#(eq(#skin.layout.movingpictures.details,'lite'))">movingpictures.details.lite.xml</include>
+    <!--MediaInfo Details-->
+    <include condition="#(not(eq(#skin.layout.movingpictures.details,'lite')))">movingpictures.mediainfo.details.xml</include>
+    <include condition="#(eq(#skin.layout.movingpictures.details,'lite'))">movingpictures.mediainfo.details.lite.xml</include>
+
+    <import>common.overlay.xml</import>
+    <!-- Fade out the screen when playback starts -->
+    <control>
+      <description>Playback Indicator</description>
+      <type>image</type>
+      <id>18</id>
+      <posX>0</posX>
+      <posY>0</posY>
+      <width>1920</width>
+      <height>1080</height>
+      <texture>black.png</texture>
+      <colordiffuse>50fefaff</colordiffuse>
+    </control>
+  </controls>
+</window>


### PR DESCRIPTION
Moving Pictures time, weather and movies icon disappear on movingpictures.details.

This is acheived by updating and adding movingpictures.xml to display the movie icon.
<texture>icon_movies.png</texture> updated visible value to <visible>!Control.HasFocus(10005)</visible>

Added override control from common.time.xml to display unless on the fanart only view.
Look for control with <description>DUMMY Visible Control common.time override</description>

It's possible that an override is not the way to do this and common.time.xml should instead be updated.
