### PR TITLE
Update for Trakt to allow FanartHandler paths for Clearart in movies

### DIFF
--- a/Common/TVSeries.ArtworkChooser.xml
+++ b/Common/TVSeries.ArtworkChooser.xml
@@ -5,7 +5,7 @@
 	<allowoverlay>yes</allowoverlay>
   <define>#header.label:#TVSeries.Translation.Artwork.Label</define>
 	<controls>
-    
+
     <control>
       <description>DEFAULT BACKGROUND</description>
       <type>image</type>
@@ -152,7 +152,7 @@
    		<posY>150</posY>
    		<width>250</width>
    		<height>140</height>
-   		<texture>..\..\..\Thumbs\ClearArt\Series\#(string.trim(#TVSeries.Series.ID)).png</texture>
+   		<texture>#fanarthandler.series.clearart.selected</texture>
    		<visible>![facadeview.filmstrip|facadeview.coverflow]</visible>
 		<animation effect="fade" time="500">WindowOpen</animation>
 		<animation effect="fade" time="250">WindowClose</animation>
@@ -167,7 +167,7 @@
    		<width>250</width>
    		<height>140</height>
    		<visible>[facadeview.filmstrip|facadeview.coverflow]</visible>
-		<texture>..\..\..\Thumbs\ClearArt\Series\#(string.trim(#TVSeries.Series.ID)).png</texture>
+		<texture>#fanarthandler.series.clearart.selected</texture>
 		<animation effect="fade" time="500">WindowOpen</animation>
 		<animation effect="fade" time="250">WindowClose</animation>
    	</control>  
@@ -181,7 +181,7 @@
    		<posY>150</posY>
    		<width>250</width>
    		<height>140</height>
-   		<texture>..\..\..\Thumbs\ClearLogo\Series\#(string.trim(#TVSeries.Series.ID)).png</texture>
+   		<texture>#fanarthandler.series.clearlogo.selected</texture>
    		<visible>![facadeview.filmstrip|facadeview.coverflow|control.hasthumb(159357)]</visible>
 		<animation effect="fade" time="500">WindowOpen</animation>
 		<animation effect="fade" time="250">WindowClose</animation>
@@ -195,7 +195,7 @@
    		<posY>440</posY>
    		<width>250</width>
    		<height>140</height>
-   		<texture>..\..\..\Thumbs\ClearLogo\Series\#(string.trim(#TVSeries.Series.ID)).png</texture>
+   		<texture>#fanarthandler.series.clearlogo.selected</texture>
    		<visible>[facadeview.filmstrip|facadeview.coverflow]+!control.hasthumb(159358)</visible>
 		<animation effect="fade" time="500">WindowOpen</animation>
 		<animation effect="fade" time="250">WindowClose</animation>

--- a/Common/TVSeries.ArtworkChooser.xml
+++ b/Common/TVSeries.ArtworkChooser.xml
@@ -152,7 +152,7 @@
    		<posY>150</posY>
    		<width>250</width>
    		<height>140</height>
-   		<texture>#fanarthandler.series.clearart.selected</texture>
+   		<texture>#fanarthandler.tvseries.clearart.selected</texture>
    		<visible>![facadeview.filmstrip|facadeview.coverflow]</visible>
 		<animation effect="fade" time="500">WindowOpen</animation>
 		<animation effect="fade" time="250">WindowClose</animation>
@@ -167,7 +167,7 @@
    		<width>250</width>
    		<height>140</height>
    		<visible>[facadeview.filmstrip|facadeview.coverflow]</visible>
-		<texture>#fanarthandler.series.clearart.selected</texture>
+		<texture>#fanarthandler.tvseries.clearart.selected</texture>
 		<animation effect="fade" time="500">WindowOpen</animation>
 		<animation effect="fade" time="250">WindowClose</animation>
    	</control>  
@@ -181,7 +181,7 @@
    		<posY>150</posY>
    		<width>250</width>
    		<height>140</height>
-   		<texture>#fanarthandler.series.clearlogo.selected</texture>
+   		<texture>#fanarthandler.tvseries.clearlogo.selected</texture>
    		<visible>![facadeview.filmstrip|facadeview.coverflow|control.hasthumb(159357)]</visible>
 		<animation effect="fade" time="500">WindowOpen</animation>
 		<animation effect="fade" time="250">WindowClose</animation>
@@ -195,7 +195,7 @@
    		<posY>440</posY>
    		<width>250</width>
    		<height>140</height>
-   		<texture>#fanarthandler.series.clearlogo.selected</texture>
+   		<texture>#fanarthandler.tvseries.clearlogo.selected</texture>
    		<visible>[facadeview.filmstrip|facadeview.coverflow]+!control.hasthumb(159358)</visible>
 		<animation effect="fade" time="500">WindowOpen</animation>
 		<animation effect="fade" time="250">WindowClose</animation>

--- a/Common/TVSeries.views.widebanner.4x2.xml
+++ b/Common/TVSeries.views.widebanner.4x2.xml
@@ -11,7 +11,7 @@
    		<posY>150</posY>
    		<width>250</width>
    		<height>140</height>
-   		<texture>#fanarthandler.series.clearart.selected</texture>
+   		<texture>#fanarthandler.tvseries.clearart.selected</texture>
    		<visible>![facadeview.filmstrip|facadeview.coverflow]</visible>
 		<animation effect="fade" time="500">WindowOpen</animation>
 		<animation effect="fade" time="250">WindowClose</animation>
@@ -26,7 +26,7 @@
    		<width>250</width>
    		<height>140</height>
    		<visible>[facadeview.filmstrip|facadeview.coverflow]</visible>
-		<texture>#fanarthandler.series.clearart.selected</texture>
+		<texture>#fanarthandler.tvseries.clearart.selected</texture>
 		<animation effect="fade" time="500">WindowOpen</animation>
 		<animation effect="fade" time="250">WindowClose</animation>
    	</control>  
@@ -40,7 +40,7 @@
    		<posY>150</posY>
    		<width>250</width>
    		<height>140</height>
-   		<texture>#fanarthandler.series.clearlogo.selected</texture>
+   		<texture>#fanarthandler.tvseries.clearlogo.selected</texture>
    		<visible>![facadeview.filmstrip|facadeview.coverflow|control.hasthumb(159357)]</visible>
 		<animation effect="fade" time="500">WindowOpen</animation>
 		<animation effect="fade" time="250">WindowClose</animation>
@@ -54,7 +54,7 @@
    		<posY>440</posY>
    		<width>250</width>
    		<height>140</height>
-   		<texture>#fanarthandler.series.clearlogo.selected</texture>
+   		<texture>#fanarthandler.tvseries.clearlogo.selected</texture>
    		<visible>[facadeview.filmstrip|facadeview.coverflow]+!control.hasthumb(159358)</visible>
 		<animation effect="fade" time="500">WindowOpen</animation>
 		<animation effect="fade" time="250">WindowClose</animation>

--- a/Common/TVSeries.views.widebanner.4x2.xml
+++ b/Common/TVSeries.views.widebanner.4x2.xml
@@ -11,7 +11,7 @@
    		<posY>150</posY>
    		<width>250</width>
    		<height>140</height>
-   		<texture>..\..\..\Thumbs\ClearArt\Series\#(string.trim(#TVSeries.Series.ID)).png</texture>
+   		<texture>#fanarthandler.series.clearart.selected</texture>
    		<visible>![facadeview.filmstrip|facadeview.coverflow]</visible>
 		<animation effect="fade" time="500">WindowOpen</animation>
 		<animation effect="fade" time="250">WindowClose</animation>
@@ -26,7 +26,7 @@
    		<width>250</width>
    		<height>140</height>
    		<visible>[facadeview.filmstrip|facadeview.coverflow]</visible>
-		<texture>..\..\..\Thumbs\ClearArt\Series\#(string.trim(#TVSeries.Series.ID)).png</texture>
+		<texture>#fanarthandler.series.clearart.selected</texture>
 		<animation effect="fade" time="500">WindowOpen</animation>
 		<animation effect="fade" time="250">WindowClose</animation>
    	</control>  
@@ -40,7 +40,7 @@
    		<posY>150</posY>
    		<width>250</width>
    		<height>140</height>
-   		<texture>..\..\..\Thumbs\ClearLogo\Series\#(string.trim(#TVSeries.Series.ID)).png</texture>
+   		<texture>#fanarthandler.series.clearlogo.selected</texture>
    		<visible>![facadeview.filmstrip|facadeview.coverflow|control.hasthumb(159357)]</visible>
 		<animation effect="fade" time="500">WindowOpen</animation>
 		<animation effect="fade" time="250">WindowClose</animation>
@@ -54,7 +54,7 @@
    		<posY>440</posY>
    		<width>250</width>
    		<height>140</height>
-   		<texture>..\..\..\Thumbs\ClearLogo\Series\#(string.trim(#TVSeries.Series.ID)).png</texture>
+   		<texture>#fanarthandler.series.clearlogo.selected</texture>
    		<visible>[facadeview.filmstrip|facadeview.coverflow]+!control.hasthumb(159358)</visible>
 		<animation effect="fade" time="500">WindowOpen</animation>
 		<animation effect="fade" time="250">WindowClose</animation>

--- a/Common/TVSeries.views.widebanner.6x2.xml
+++ b/Common/TVSeries.views.widebanner.6x2.xml
@@ -11,7 +11,7 @@
    		<posY>150</posY>
    		<width>250</width>
    		<height>140</height>
-   		<texture>#fanarthandler.series.clearart.selected</texture>
+   		<texture>#fanarthandler.tvseries.clearart.selected</texture>
    		<visible>![facadeview.filmstrip|facadeview.coverflow]</visible>
 		<animation effect="fade" time="500">WindowOpen</animation>
 		<animation effect="fade" time="250">WindowClose</animation>
@@ -26,7 +26,7 @@
    		<width>250</width>
    		<height>140</height>
    		<visible>[facadeview.filmstrip|facadeview.coverflow]</visible>
-		<texture>#fanarthandler.series.clearart.selected</texture>
+		<texture>#fanarthandler.tvseries.clearart.selected</texture>
 		<animation effect="fade" time="500">WindowOpen</animation>
 		<animation effect="fade" time="250">WindowClose</animation>
    	</control>  
@@ -40,7 +40,7 @@
    		<posY>150</posY>
    		<width>250</width>
    		<height>140</height>
-   		<texture>#fanarthandler.series.clearlogo.selected</texture>
+   		<texture>#fanarthandler.tvseries.clearlogo.selected</texture>
    		<visible>![facadeview.filmstrip|facadeview.coverflow|control.hasthumb(159357)]</visible>
 		<animation effect="fade" time="500">WindowOpen</animation>
 		<animation effect="fade" time="250">WindowClose</animation>
@@ -54,7 +54,7 @@
    		<posY>440</posY>
    		<width>250</width>
    		<height>140</height>
-   		<texture>#fanarthandler.series.clearlogo.selected</texture>
+   		<texture>#fanarthandler.tvseries.clearlogo.selected</texture>
    		<visible>[facadeview.filmstrip|facadeview.coverflow]+!control.hasthumb(159358)</visible>
 		<animation effect="fade" time="500">WindowOpen</animation>
 		<animation effect="fade" time="250">WindowClose</animation>

--- a/Common/TVSeries.views.widebanner.6x2.xml
+++ b/Common/TVSeries.views.widebanner.6x2.xml
@@ -11,7 +11,7 @@
    		<posY>150</posY>
    		<width>250</width>
    		<height>140</height>
-   		<texture>..\..\..\Thumbs\ClearArt\Series\#(string.trim(#TVSeries.Series.ID)).png</texture>
+   		<texture>#fanarthandler.series.clearart.selected</texture>
    		<visible>![facadeview.filmstrip|facadeview.coverflow]</visible>
 		<animation effect="fade" time="500">WindowOpen</animation>
 		<animation effect="fade" time="250">WindowClose</animation>
@@ -26,7 +26,7 @@
    		<width>250</width>
    		<height>140</height>
    		<visible>[facadeview.filmstrip|facadeview.coverflow]</visible>
-		<texture>..\..\..\Thumbs\ClearArt\Series\#(string.trim(#TVSeries.Series.ID)).png</texture>
+		<texture>#fanarthandler.series.clearart.selected</texture>
 		<animation effect="fade" time="500">WindowOpen</animation>
 		<animation effect="fade" time="250">WindowClose</animation>
    	</control>  
@@ -40,7 +40,7 @@
    		<posY>150</posY>
    		<width>250</width>
    		<height>140</height>
-   		<texture>..\..\..\Thumbs\ClearLogo\Series\#(string.trim(#TVSeries.Series.ID)).png</texture>
+   		<texture>#fanarthandler.series.clearlogo.selected</texture>
    		<visible>![facadeview.filmstrip|facadeview.coverflow|control.hasthumb(159357)]</visible>
 		<animation effect="fade" time="500">WindowOpen</animation>
 		<animation effect="fade" time="250">WindowClose</animation>
@@ -54,7 +54,7 @@
    		<posY>440</posY>
    		<width>250</width>
    		<height>140</height>
-   		<texture>..\..\..\Thumbs\ClearLogo\Series\#(string.trim(#TVSeries.Series.ID)).png</texture>
+   		<texture>#fanarthandler.series.clearlogo.selected</texture>
    		<visible>[facadeview.filmstrip|facadeview.coverflow]+!control.hasthumb(159358)</visible>
 		<animation effect="fade" time="500">WindowOpen</animation>
 		<animation effect="fade" time="250">WindowClose</animation>

--- a/Common/TVSeries.views.widebanner.default.xml
+++ b/Common/TVSeries.views.widebanner.default.xml
@@ -11,7 +11,7 @@
    		<posY>150</posY>
    		<width>250</width>
    		<height>140</height>
-   		<texture>#fanarthandler.series.clearart.selected</texture>
+   		<texture>#fanarthandler.tvseries.clearart.selected</texture>
    		<visible>![facadeview.filmstrip|facadeview.coverflow]</visible>
 		<animation effect="fade" time="500">WindowOpen</animation>
 		<animation effect="fade" time="250">WindowClose</animation>
@@ -26,7 +26,7 @@
    		<width>250</width>
    		<height>140</height>
    		<visible>[facadeview.filmstrip|facadeview.coverflow]</visible>
-		<texture>#fanarthandler.series.clearart.selected</texture>
+		<texture>#fanarthandler.tvseries.clearart.selected</texture>
 		<animation effect="fade" time="500">WindowOpen</animation>
 		<animation effect="fade" time="250">WindowClose</animation>
    	</control>  
@@ -40,7 +40,7 @@
    		<posY>150</posY>
    		<width>250</width>
    		<height>140</height>
-   		<texture>#fanarthandler.series.clearlogo.selected</texture>
+   		<texture>#fanarthandler.tvseries.clearlogo.selected</texture>
    		<visible>![facadeview.filmstrip|facadeview.coverflow|control.hasthumb(159357)]</visible>
 		<animation effect="fade" time="500">WindowOpen</animation>
 		<animation effect="fade" time="250">WindowClose</animation>
@@ -54,7 +54,7 @@
    		<posY>440</posY>
    		<width>250</width>
    		<height>140</height>
-   		<texture>#fanarthandler.series.clearlogo.selected</texture>
+   		<texture>#fanarthandler.tvseries.clearlogo.selected</texture>
    		<visible>[facadeview.filmstrip|facadeview.coverflow]+!control.hasthumb(159358)</visible>
 		<animation effect="fade" time="500">WindowOpen</animation>
 		<animation effect="fade" time="250">WindowClose</animation>

--- a/Common/TVSeries.views.widebanner.default.xml
+++ b/Common/TVSeries.views.widebanner.default.xml
@@ -11,7 +11,7 @@
    		<posY>150</posY>
    		<width>250</width>
    		<height>140</height>
-   		<texture>..\..\..\Thumbs\ClearArt\Series\#(string.trim(#TVSeries.Series.ID)).png</texture>
+   		<texture>#fanarthandler.series.clearart.selected</texture>
    		<visible>![facadeview.filmstrip|facadeview.coverflow]</visible>
 		<animation effect="fade" time="500">WindowOpen</animation>
 		<animation effect="fade" time="250">WindowClose</animation>
@@ -26,7 +26,7 @@
    		<width>250</width>
    		<height>140</height>
    		<visible>[facadeview.filmstrip|facadeview.coverflow]</visible>
-		<texture>..\..\..\Thumbs\ClearArt\Series\#(string.trim(#TVSeries.Series.ID)).png</texture>
+		<texture>#fanarthandler.series.clearart.selected</texture>
 		<animation effect="fade" time="500">WindowOpen</animation>
 		<animation effect="fade" time="250">WindowClose</animation>
    	</control>  
@@ -40,7 +40,7 @@
    		<posY>150</posY>
    		<width>250</width>
    		<height>140</height>
-   		<texture>..\..\..\Thumbs\ClearLogo\Series\#(string.trim(#TVSeries.Series.ID)).png</texture>
+   		<texture>#fanarthandler.series.clearlogo.selected</texture>
    		<visible>![facadeview.filmstrip|facadeview.coverflow|control.hasthumb(159357)]</visible>
 		<animation effect="fade" time="500">WindowOpen</animation>
 		<animation effect="fade" time="250">WindowClose</animation>
@@ -54,7 +54,7 @@
    		<posY>440</posY>
    		<width>250</width>
    		<height>140</height>
-   		<texture>..\..\..\Thumbs\ClearLogo\Series\#(string.trim(#TVSeries.Series.ID)).png</texture>
+   		<texture>#fanarthandler.series.clearlogo.selected</texture>
    		<visible>[facadeview.filmstrip|facadeview.coverflow]+!control.hasthumb(159358)</visible>
 		<animation effect="fade" time="500">WindowOpen</animation>
 		<animation effect="fade" time="250">WindowClose</animation>

--- a/Common/TVSeries.xml
+++ b/Common/TVSeries.xml
@@ -6,6 +6,7 @@
   <define>#useSelectedFanart:Yes</define>
   <define>#header.label:#TVSeries.Translation.Series_Plural.Label</define>
   <controls>
+  <!-- #TVSeries.Series.ID -->
     <!-- Import Dummy Controls to handle visibility -->
     <import>TVSeries.dummy.xml</import>
     <!-- ********************** BACKGROUNDS************************************** -->

--- a/Common/Trakt.Anticipated.Movies.xml
+++ b/Common/Trakt.Anticipated.Movies.xml
@@ -1,0 +1,457 @@
+<?xml version="1.0" encoding="utf-8" standalone="yes"?>
+<window>
+  <id>87605</id>
+  <defaultcontrol>50</defaultcontrol>
+  <allowoverlay>no</allowoverlay>
+  <define>#Fanart.1:#Trakt.AnticipatedMovies.Fanart.1</define>
+  <define>#Fanart.2:#Trakt.AnticipatedMovies.Fanart.2</define>
+  <define>#header.label:#Trakt.Translation.AnticipatedMovies.Label</define>
+  <controls>
+  <!-- #fanarthandler.movie.genres.selected -->
+    <control>
+      <description>DEFAULT BACKGROUND</description>
+      <type>image</type>
+      <id>0</id>
+      <posX>0</posX>
+      <posY>0</posY>
+      <width>1920</width>
+      <height>1080</height>
+      <texture>background.png</texture>
+      <shouldCache>true</shouldCache>
+    </control>
+    <import>Trakt.Common.Fanart.xml</import>
+    <!--            :: BACKGROUNDS ::           	 -->
+    <control>
+      <description>background listview</description>
+      <type>image</type>
+      <id>0</id>
+      <posX>0</posX>
+      <posY>0</posY>
+      <width>1920</width>
+      <height>1080</height>
+      <texture>fanart_overlay.png</texture>
+      <visible>!Control.IsVisible(51)</visible>
+      <animation effect="fade" time="250">WindowOpen</animation>
+      <animation effect="fade" time="250">WindowClose</animation>
+    </control>
+    <control>
+      <description>background listview</description>
+      <type>image</type>
+      <id>0</id>
+      <posX>10</posX>
+      <posY>252</posY>
+      <width>1903</width>
+      <height>790</height>
+      <texture>panel_list.png</texture>
+      <visible>facadeview.list + Control.IsVisible(50)</visible>
+      <animation effect="fade" time="250">WindowOpen</animation>
+      <animation effect="fade" time="250">WindowClose</animation>
+    </control>
+    <control>
+      <description>background thumbs</description>
+      <type>image</type>
+      <id>0</id>
+      <posX>10</posX>
+      <posY>252</posY>
+      <width>1903</width>
+      <height>790</height>
+      <texture>panel_tvseries_widebanner.6x2.png</texture>
+      <visible>[facadeview.smallicons | facadeview.largeicons] + Control.IsVisible(50)</visible>
+      <animation effect="fade" time="250">WindowOpen</animation>
+      <animation effect="fade" time="250">WindowClose</animation>
+    </control>
+    <control>
+      <description>filmstrip overlay</description>
+      <type>image</type>
+      <id>0</id>
+      <posX>0</posX>
+      <posY>279</posY>
+      <width>1920</width>
+      <height>801</height>
+      <texture>filmstrip_overlay.png</texture>
+      <visible>[facadeview.filmstrip | facadeview.coverflow] + Control.IsVisible(50)</visible>
+      <animation effect="fade" time="250">WindowOpen</animation>
+      <animation effect="fade" time="250">WindowClose</animation>
+    </control>
+    <control>
+      <description>filmstrip overlay</description>
+      <type>image</type>
+      <id>0</id>
+      <posX>52</posX>
+      <posY>958</posY>
+      <width>1820</width>
+      <height>84</height>
+      <texture>BasicHomeSubBG.png</texture>
+      <visible>[facadeview.filmstrip | facadeview.coverflow] + Control.IsVisible(50)</visible>
+      <animation effect="fade" time="250">WindowOpen</animation>
+      <animation effect="fade" time="250">WindowClose</animation>
+    </control>
+    <control>
+      <id>0</id>
+      <type>image</type>
+      <posX>66</posX>
+      <posY>34</posY>
+      <width>61</width>
+      <height>60</height>
+      <texture>icon_movies.png</texture>
+      <animation effect="fade" time="250">WindowOpen</animation>
+      <animation effect="fade" time="250">WindowClose</animation>
+    </control>
+    <import>common.time.xml</import>
+    <control>
+      <description>trakt</description>
+      <type>label</type>
+      <label>Trakt</label>
+      <id>0</id>
+      <posX>144</posX>
+      <posY>94</posY>
+      <width>1100</width>
+      <align>left</align>
+      <textcolor>FFFFFFFF</textcolor>
+      <font>TitanLight12</font>
+      <animation effect="fade" time="250">WindowOpen</animation>
+      <animation effect="fade" time="250">WindowClose</animation>
+    </control>
+    <!--            :: Count ::            -->
+    <control>
+      <description>Moviecount</description>
+      <type>label</type>
+      <label>#Trakt.Translation.Movies.Label: #itemcount</label>
+      <id>0</id>
+      <posX>96</posX>
+      <posY>998</posY>
+      <align>left</align>
+      <font>TitanLight12</font>
+      <textcolor>000000</textcolor>
+      <visible>[facadeview.list | facadeview.smallicons | facadeview.largeicons | facadeview.filmstrip | facadeview.coverflow] + control.isvisible(50)</visible>
+      <animation effect="fade" time="250">WindowOpen</animation>
+      <animation effect="fade" time="250">WindowClose</animation>
+    </control>
+    <!--            :: Listview Lines ::            -->
+    <control>
+      <description>List Lines</description>
+      <type>image</type>
+      <id>1</id>
+      <posX>1222</posX>
+      <posY>385</posY>
+      <width>607</width>
+      <height>506</height>
+      <texture>list_lines.png</texture>
+      <visible>facadeview.list + control.isvisible(50)</visible>
+      <animation effect="fade" time="250">WindowOpen</animation>
+      <animation effect="fade" time="250">WindowClose</animation>
+    </control>
+    <control>
+      <description>group element</description>
+      <type>group</type>
+      <animation effect="fade" time="250">WindowOpen</animation>
+      <animation effect="fade" time="250">WindowClose</animation>
+      <control>
+        <type>facadeview</type>
+        <id>50</id>
+        <control>
+          <description>Movie List</description>
+          <type>listcontrol</type>
+          <id>50</id>
+          <onleft>2</onleft>
+          <onright>2</onright>
+          <scrollOffset>1</scrollOffset>
+          <posX>1165</posX>
+          <posY>331</posY>
+          <height>700</height>
+          <width>698</width>
+          <textXOff>44</textXOff>
+          <textXOff2>650</textXOff2>
+          <textureHeight>54</textureHeight>
+          <textureFocus>listcontrol_item_selected.png</textureFocus>
+          <textureNoFocus>-</textureNoFocus>
+          <dimColor>ffffffff</dimColor>
+          <spinPosX>1828</spinPosX>
+          <spinPosY>1000</spinPosY>
+        </control>
+        <control>
+          <description>Filmstrip view</description>
+          <type>filmstrip</type>
+          <dimColor>90ffffff</dimColor>
+          <id>50</id>
+          <scrollOffset>3</scrollOffset>
+          <folderPrefix></folderPrefix>
+          <folderSuffix></folderSuffix>
+          <posX>130</posX>
+          <posY>595</posY>
+          <width>1700</width>
+          <height>340</height>
+          <onup>2</onup>
+          <ondown>2</ondown>
+          <onleft>50</onleft>
+          <onright>50</onright>
+          <thumbWidth>230</thumbWidth>
+          <thumbHeight>327</thumbHeight>
+          <thumbPosX>0</thumbPosX>
+          <thumbPosY>0</thumbPosY>
+          <itemWidth>240</itemWidth>
+          <itemHeight>327</itemHeight>
+          <textureWidth>230</textureWidth>
+          <textureHeight>327</textureHeight>
+          <textYOff>-2000</textYOff>
+          <imageFolderFocus>-</imageFolderFocus>
+          <frame>-</frame>
+          <frameFocus>-</frameFocus>
+          <background>-</background>
+          <thumbs flipY="true" diffuse="Thumb_Mask_test.png" mask="filmstrip_mask.png"></thumbs>
+          <showFrame>yes</showFrame>
+          <showFolder>no</showFolder>
+          <showBackGround>no</showBackGround>
+          <showInfoImage>no</showInfoImage>
+          <scrollbarBackground>scrollbar_bg_hor.png</scrollbarBackground>
+          <scrollbarLeft>scrollbar_left_hor.png</scrollbarLeft>
+          <scrollbarRight>scrollbar_right_hor.png</scrollbarRight>
+          <scrollbarWidth>717</scrollbarWidth>
+          <scrollbarHeight>8</scrollbarHeight>
+          <scrollbarYOff>375</scrollbarYOff>
+          <keepaspectratio>no</keepaspectratio>
+          <thumbAnimation effect="zoom" acceleration="-2" start="100,100" reversible="false" end="120,120" center="0,880" time="200">focus</thumbAnimation>
+          <thumbAnimation effect="zoom" start="120,120" reversible="false" end="100,100" center="0,880" time="100">unfocus</thumbAnimation>
+        </control>
+        <control>
+          <description>Thumbnail Panel</description>
+          <type>thumbnailpanel</type>
+          <id>50</id>
+          <posX>754</posX>
+          <posY>342</posY>
+          <width>1150</width>
+          <height>700</height>
+          <folderPrefix></folderPrefix>
+          <folderSuffix></folderSuffix>
+          <onleft>2</onleft>
+          <onright>2</onright>
+          <itemWidth>138</itemWidth>
+          <itemHeight>196</itemHeight>
+          <textureWidth>138</textureWidth>
+          <textureHeight>196</textureHeight>
+          <thumbWidth>128</thumbWidth>
+          <thumbHeight>186</thumbHeight>
+          <thumbPosX>6</thumbPosX>
+          <thumbPosY>5</thumbPosY>
+          <itemWidthBig>214</itemWidthBig>
+          <itemHeightBig>304</itemHeightBig>
+          <thumbWidthBig>204</thumbWidthBig>
+          <thumbHeightBig>294</thumbHeightBig>
+          <textureWidthBig>216</textureWidthBig>
+          <textureHeightBig>304</textureHeightBig>
+          <thumbPosXBig>6</thumbPosXBig>
+          <thumbPosYBig>5</thumbPosYBig>
+          <zoomXPixels>0</zoomXPixels>
+          <zoomYPixels>0</zoomYPixels>
+          <hideUnfocusTexture>no</hideUnfocusTexture>
+          <keepaspectratio>no</keepaspectratio>
+          <renderFocusText>no</renderFocusText>
+          <renderUnfocusText>no</renderUnfocusText>
+          <frameNoFocus>-</frameNoFocus>
+          <frameFocus>video_thumb_focus.png</frameFocus>
+          <textureMask></textureMask>
+          <shadowAngle>90</shadowAngle>
+          <shadowDistance>50</shadowDistance>
+          <thumbZoom>no</thumbZoom>
+          <spinPosX>1828</spinPosX>
+          <spinPosY>1000</spinPosY>
+          <unfocusedAlpha>100</unfocusedAlpha>
+        </control>
+        <control>
+          <description>Cover Flow view</description>
+          <type>coverflow</type>
+          <colordiffuse>90ffffff</colordiffuse>
+          <dimColor>90ffffff</dimColor>
+          <id>50</id>
+          <onup>2</onup>
+          <ondown>2</ondown>
+          <onleft>50</onleft>
+          <onright>50</onright>
+          <posX>0</posX>
+          <posY>595</posY>
+          <width>1920</width>
+          <height>340</height>
+          <selectedCard>0</selectedCard>
+          <cardWidth>238</cardWidth>
+          <cardHeight>340</cardHeight>
+          <angle>55</angle>
+          <sideShift>150</sideShift>
+          <sideGap>120</sideGap>
+          <sideDepth>110</sideDepth>
+          <offsetY>0</offsetY>
+          <selectedOffsetY>0</selectedOffsetY>
+          <speed>10</speed>
+          <showFrame>yes</showFrame>
+          <frame>-</frame>
+          <frameFocus>-</frameFocus>
+          <keepaspectratio>no</keepaspectratio>
+          <frameWidth>238</frameWidth>
+          <frameHeight>340</frameHeight>
+          <spinSpeed>8</spinSpeed>
+          <unfocusedAlpha>FF</unfocusedAlpha>
+          <folderPrefix></folderPrefix>
+          <folderSuffix></folderSuffix>
+          <font1>font13</font1>
+          <font2>font11</font2>
+          <label1>#title</label1>
+          <label2>#genre</label2>
+          <textColor>FFFFFFFF</textColor>
+          <remoteColor>FFFF0000</remoteColor>
+          <playedColor>FFA0D0FF</playedColor>
+          <downloadColor>FF00FF00</downloadColor>
+          <selectedColor>FFFFFFFF</selectedColor>
+          <shadowAngle>45</shadowAngle>
+          <shadowDistance>1</shadowDistance>
+          <shadowColor>FF000000</shadowColor>
+          <label1YOff>1430</label1YOff>
+          <label2YOff>1390</label2YOff>
+          <pageSize>5</pageSize>
+          <scrollbarBackground>scrollbar_bg_hor.png</scrollbarBackground>
+          <scrollbarLeft>scrollbar_left_hor.png</scrollbarLeft>
+          <scrollbarRight>scrollbar_right_hor.png</scrollbarRight>
+          <scrollbarWidth>717</scrollbarWidth>
+          <scrollbarHeight>8</scrollbarHeight>
+          <scrollbarYOff>375</scrollbarYOff>
+          <cards flipY="true" diffuse="Thumb_Mask_test.png" mask="filmstrip_mask.png"></cards>
+        </control>
+      </control>
+    </control>
+    <!--            :: HIDDEN MENU ::           	 -->
+    <control>
+      <id>1</id>
+      <type>image</type>
+      <posX>0</posX>
+      <posY>440</posY>
+      <width>64</width>
+      <height>199</height>
+      <texture>hiddenmenu_tab.png</texture>
+      <visible>[facadeview.list | facadeview.smallicons | facadeview.largeicons]+Control.HasFocus(50) + !string.contains(#Titan.HiddenMenu, false)</visible>
+      <animation effect="slide" start="-60,0" end="0,0" tween="quadratic" easing="in" time="250" delay="400">WindowOpen</animation>
+      <animation effect="slide" start="0,0" end="-60,0" tween="quadratic" easing="in" time="250" delay="100">WindowClose</animation>
+    </control>
+    <control>
+      <id>1</id>
+      <type>image</type>
+      <posX>858</posX>
+      <posY>0</posY>
+      <texture>hiddenmenu_tab_up.png</texture>
+      <visible>[facadeview.filmstrip | facadeview.coverflow] + Control.HasFocus(50) + !string.contains(#Titan.HiddenMenu, false)</visible>
+      <animation effect="slide" start="0,-60" end="0,0" tween="quadratic" easing="in" time="250" delay="400">WindowOpen</animation>
+      <animation effect="slide" start="0,0" end="0,-60" tween="quadratic" easing="in" time="250" delay="100">WindowClose</animation>
+    </control>
+    <control>
+      <type>actiongroup</type>
+      <description>action menu</description>
+      <defaultcontrol>3</defaultcontrol>
+      <onexit>50</onexit>
+      <dimColor>00ffffff</dimColor>
+      <buttonX>-460</buttonX>
+      <buttonY>155</buttonY>
+      <buttonwidth>499</buttonwidth>
+      <buttonheight>1080</buttonheight>
+      <control>
+        <type>image</type>
+        <id>0</id>
+        <width>1920</width>
+        <height>1080</height>
+        <texture>semi_trans_back_hidden_menu.png</texture>
+        <visible>!Control.HasFocus(50)+control.isvisible(50)</visible>
+        <animation effect="fade" time="450">visible</animation>
+        <animation effect="fade" time="400">hidden</animation>
+      </control>
+      <control>
+        <type>image</type>
+        <id>0</id>
+        <posY>0</posY>
+        <posX>0</posX>
+        <width>612</width>
+        <height>1074</height>
+        <texture>menu_bg.png</texture>
+        <visible>!Control.HasFocus(50)+control.isvisible(50)</visible>
+        <animation effect="fade" time="0">WindowClose</animation>
+        <animation effect="slide" start="-150,0" time="100">visible</animation>
+        <animation effect="fade" time="50">visible</animation>
+        <animation effect="fade" time="0">hidden</animation>
+      </control>
+      <control>
+        <description>Menu label</description>
+        <type>label</type>
+        <id>1</id>
+        <posX>116</posX>
+        <posY>100</posY>
+        <label>924</label>
+        <font>fontB16</font>
+        <textcolor>393939</textcolor>
+        <visible>!Control.HasFocus(50)+control.isvisible(50)</visible>
+        <animation effect="fade" time="0">WindowClose</animation>
+        <animation effect="slide" start="-150,0" time="100">visible</animation>
+        <animation effect="fade" time="50">visible</animation>
+        <animation effect="fade" time="0">hidden</animation>
+      </control>
+      <control>
+        <type>group</type>
+        <description>group element</description>
+        <visible>!Control.HasFocus(50)+control.isvisible(50)</visible>
+        <animation effect="fade" time="0">WindowClose</animation>
+        <animation effect="slide" start="-150,0" time="100">visible</animation>
+        <animation effect="fade" time="50">visible</animation>
+        <animation effect="fade" time="0">hidden</animation>
+        <posX>53</posX>
+        <posY>155</posY>
+        <layout>StackLayout(0, Vertical, true)</layout>
+        <control>
+          <description>Change Layout</description>
+          <type>button</type>
+          <id>2</id>
+          <textureFocus>hiddenmenu_item_selected.png</textureFocus>
+          <textureNoFocus>-</textureNoFocus>
+          <width>499</width>
+          <height>69</height>
+          <textXOff>62</textXOff>
+          <textYOff>16</textYOff>
+          <label>-</label>
+          <onright>50</onright>
+          <ondown>8</ondown>
+          <onup>8</onup>
+        </control>
+        <control>
+          <description>Sort</description>
+          <type>sortbutton</type>
+          <id>8</id>
+          <label>-</label>
+          <textureFocus>hiddenmenu_item_selected.png</textureFocus>
+          <textureNoFocus>-</textureNoFocus>
+          <width>499</width>
+          <height>69</height>
+          <textXOff>62</textXOff>
+          <textYOff>16</textYOff>
+          <offsetSortButtonX>421</offsetSortButtonX>
+          <offsetSortButtonY>27</offsetSortButtonY>
+          <onright>50</onright>
+          <onleft>50</onleft>
+          <ondown>10</ondown>
+          <onup>2</onup>
+        </control>
+        <control>
+          <description>Hide Watchlisted</description>
+          <type>checkbutton</type>
+          <id>10</id>
+          <width>499</width>
+          <height>69</height>
+          <textureFocus>hiddenmenu_item_selected.png</textureFocus>
+          <textureNoFocus>-</textureNoFocus>
+          <textcolorNoFocus>ff393939</textcolorNoFocus>
+          <label>#Trakt.Translation.HideWatchlisted.Label</label>
+          <onup>9</onup>
+          <ondown>2</ondown>
+          <onright>50</onright>
+          <onleft>50</onleft>
+          <textXOff>62</textXOff>
+          <textYOff>16</textYOff>
+        </control>
+      </control>
+    </control>
+    <import>Trakt.Common.Movies.xml</import>
+    <import>common.overlay.xml</import>
+  </controls>
+</window>

--- a/Common/Trakt.Anticipated.Shows.xml
+++ b/Common/Trakt.Anticipated.Shows.xml
@@ -1,0 +1,470 @@
+<?xml version="1.0" encoding="utf-8" standalone="yes"?>
+<window>
+  <id>87606</id>
+  <defaultcontrol>50</defaultcontrol>
+  <allowoverlay>no</allowoverlay>
+  <define>#Fanart.1:#Trakt.AnticipatedShows.Fanart.1</define>
+  <define>#Fanart.2:#Trakt.AnticipatedShows.Fanart.2</define>
+  <define>#header.label:#Trakt.Translation.AnticipatedShows.Label</define>
+  <controls>
+
+    <control>
+      <description>DEFAULT BACKGROUND</description>
+      <type>image</type>
+      <id>0</id>
+      <posX>0</posX>
+      <posY>0</posY>
+      <width>1920</width>
+      <height>1080</height>
+      <texture>background.png</texture>
+      <shouldCache>true</shouldCache>
+    </control>
+
+    <import>Trakt.Common.Fanart.xml</import>
+
+    <!--            :: BACKGROUNDS ::           	 -->
+
+    <control>
+      <description>background listview</description>
+      <type>image</type>
+      <id>0</id>
+      <posX>0</posX>
+      <posY>0</posY>
+      <width>1920</width>
+      <height>1080</height>
+      <texture>fanart_overlay.png</texture>
+      <visible>[facadeview.list | facadeview.smallicons | facadeview.largeicons | facadeview.filmstrip | facadeview.coverflow] + Control.IsVisible(50)</visible>
+      <animation effect="fade" time="250">WindowOpen</animation>
+      <animation effect="fade" time="250">WindowClose</animation>
+    </control>
+
+    <control>
+      <description>background listview</description>
+      <type>image</type>
+      <id>0</id>
+      <posX>10</posX>
+      <posY>252</posY>
+      <width>1903</width>
+      <height>790</height>
+      <texture>panel_list.png</texture>
+      <visible>facadeview.list + Control.IsVisible(50)</visible>
+      <animation effect="fade" time="250">WindowOpen</animation>
+      <animation effect="fade" time="250">WindowClose</animation>
+    </control>
+
+    <control>
+      <description>background thumbs</description>
+      <type>image</type>
+      <id>0</id>
+      <posX>10</posX>
+      <posY>252</posY>
+      <width>1903</width>
+      <height>790</height>
+      <texture>panel_tvseries_widebanner.6x2.png</texture>
+      <visible>[facadeview.smallicons | facadeview.largeicons] + Control.IsVisible(50)</visible>
+      <animation effect="fade" time="250">WindowOpen</animation>
+      <animation effect="fade" time="250">WindowClose</animation>
+    </control>
+
+    <control>
+      <description>filmstrip overlay</description>
+      <type>image</type>
+      <id>0</id>
+      <posX>10</posX>
+      <posY>490</posY>
+      <width>1903</width>
+      <height>552</height>
+      <texture>panel_filmstrip.png</texture>
+      <visible>[facadeview.filmstrip | facadeview.coverflow] + Control.IsVisible(50)</visible>
+      <animation effect="fade" time="250">WindowOpen</animation>
+      <animation effect="fade" time="250">WindowClose</animation>
+    </control>
+
+    <control>
+      <id>0</id>
+      <type>image</type>
+      <posX>66</posX>
+      <posY>34</posY>
+      <width>61</width>
+      <height>60</height>
+      <texture>icon_series.png</texture>
+      <animation effect="fade" time="250">WindowOpen</animation>
+      <animation effect="fade" time="250">WindowClose</animation>
+    </control>
+
+    <import>common.time.xml</import>
+    <control>
+      <description>Trakt</description>
+      <type>label</type>
+      <label>Trakt</label>
+      <id>0</id>
+      <posX>144</posX>
+      <posY>94</posY>
+      <width>1100</width>
+      <align>left</align>
+      <textcolor>FFFFFFFF</textcolor>
+      <font>TitanLight12</font>
+      <animation effect="fade" time="250">WindowOpen</animation>
+      <animation effect="fade" time="250">WindowClose</animation>
+    </control>
+
+    <!--            :: Count ::            -->
+
+    <control>
+      <description>Show Count</description>
+      <type>label</type>
+      <label>#Trakt.Translation.Series.Label: #itemcount</label>
+      <id>0</id>
+      <posX>96</posX>
+      <posY>998</posY>
+      <align>left</align>
+      <font>TitanLight12</font>
+      <textcolor>000000</textcolor>
+      <visible>[facadeview.list | facadeview.smallicons | facadeview.largeicons | facadeview.filmstrip | facadeview.coverflow] + control.isvisible(50)</visible>
+      <animation effect="fade" time="250">WindowOpen</animation>
+      <animation effect="fade" time="250">WindowClose</animation>
+    </control>
+
+    <!--            :: Listview Lines ::            -->
+
+    <control>
+      <description>List Lines</description>
+      <type>image</type>
+      <id>1</id>
+      <posX>1222</posX>
+      <posY>385</posY>
+      <width>607</width>
+      <height>506</height>
+      <texture>list_lines.png</texture>
+      <visible>facadeview.list + control.isvisible(50)</visible>
+      <animation effect="fade" time="250">WindowOpen</animation>
+      <animation effect="fade" time="250">WindowClose</animation>
+    </control>
+
+    <control>
+      <description>group element</description>
+      <type>group</type>
+      <animation effect="fade" time="250">WindowOpen</animation>
+      <animation effect="fade" time="250">WindowClose</animation>
+      <control>
+        <type>facadeview</type>
+        <id>50</id>
+        <control>
+          <description>Movie List</description>
+          <type>listcontrol</type>
+          <id>50</id>
+          <onleft>2</onleft>
+          <onright>2</onright>
+          <scrollOffset>1</scrollOffset>
+          <posX>1165</posX>
+          <posY>331</posY>
+          <height>700</height>
+          <width>698</width>
+          <textXOff>44</textXOff>
+          <textXOff2>650</textXOff2>
+          <textureHeight>54</textureHeight>
+          <textureFocus>listcontrol_item_selected.png</textureFocus>
+          <textureNoFocus>-</textureNoFocus>
+          <dimColor>ffffffff</dimColor>
+          <spinPosX>1828</spinPosX>
+          <spinPosY>1000</spinPosY>
+        </control>
+
+        <control>
+          <description>Filmstrip view</description>
+          <type>filmstrip</type>
+          <dimColor>90ffffff</dimColor>
+          <id>50</id>
+          <scrollOffset>3</scrollOffset>
+          <folderPrefix></folderPrefix>
+          <folderSuffix></folderSuffix>
+          <posX>130</posX>
+          <posY>595</posY>
+          <width>1700</width>
+          <height>340</height>
+          <onup>2</onup>
+          <ondown>2</ondown>
+          <onleft>50</onleft>
+          <onright>50</onright>
+          <thumbWidth>230</thumbWidth>
+          <thumbHeight>327</thumbHeight>
+          <thumbPosX>0</thumbPosX>
+          <thumbPosY>0</thumbPosY>
+          <itemWidth>240</itemWidth>
+          <itemHeight>327</itemHeight>
+          <textureWidth>230</textureWidth>
+          <textureHeight>327</textureHeight>
+          <textYOff>-2000</textYOff>
+          <imageFolderFocus>-</imageFolderFocus>
+          <frame>-</frame>
+          <frameFocus>-</frameFocus>
+          <background>-</background>
+          <thumbs flipY="true" diffuse="Thumb_Mask_test.png" mask="filmstrip_mask.png"></thumbs>
+          <showFrame>yes</showFrame>
+          <showFolder>no</showFolder>
+          <showBackGround>no</showBackGround>
+          <showInfoImage>no</showInfoImage>
+          <scrollbarBackground>scrollbar_bg_hor.png</scrollbarBackground>
+          <scrollbarLeft>scrollbar_left_hor.png</scrollbarLeft>
+          <scrollbarRight>scrollbar_right_hor.png</scrollbarRight>
+          <scrollbarWidth>717</scrollbarWidth>
+          <scrollbarHeight>8</scrollbarHeight>
+          <scrollbarYOff>375</scrollbarYOff>
+          <keepaspectratio>no</keepaspectratio>
+          <thumbAnimation effect="zoom" acceleration="-2" start="100,100" reversible="false" end="120,120" center="0,880" time="200">focus</thumbAnimation>
+          <thumbAnimation effect="zoom" start="120,120" reversible="false" end="100,100" center="0,880" time="100">unfocus</thumbAnimation>
+        </control>
+
+        <control>
+          <description>Thumbnail Panel</description>
+          <type>thumbnailpanel</type>
+          <id>50</id>
+          <posX>754</posX>
+          <posY>342</posY>
+          <width>1150</width>
+          <height>700</height>
+          <folderPrefix></folderPrefix>
+          <folderSuffix></folderSuffix>
+          <onleft>2</onleft>
+          <onright>2</onright>
+          <itemWidth>138</itemWidth>
+          <itemHeight>196</itemHeight>
+          <textureWidth>138</textureWidth>
+          <textureHeight>196</textureHeight>
+          <thumbWidth>128</thumbWidth>
+          <thumbHeight>186</thumbHeight>
+          <thumbPosX>6</thumbPosX>
+          <thumbPosY>5</thumbPosY>
+          <itemWidthBig>214</itemWidthBig>
+          <itemHeightBig>304</itemHeightBig>
+          <thumbWidthBig>204</thumbWidthBig>
+          <thumbHeightBig>294</thumbHeightBig>
+          <textureWidthBig>216</textureWidthBig>
+          <textureHeightBig>304</textureHeightBig>
+          <thumbPosXBig>6</thumbPosXBig>
+          <thumbPosYBig>5</thumbPosYBig>
+          <zoomXPixels>0</zoomXPixels>
+          <zoomYPixels>0</zoomYPixels>
+          <hideUnfocusTexture>no</hideUnfocusTexture>
+          <keepaspectratio>no</keepaspectratio>
+          <renderFocusText>no</renderFocusText>
+          <renderUnfocusText>no</renderUnfocusText>
+          <frameNoFocus>-</frameNoFocus>
+          <frameFocus>video_thumb_focus.png</frameFocus>
+          <textureMask></textureMask>
+          <shadowAngle>90</shadowAngle>
+          <shadowDistance>50</shadowDistance>
+          <thumbZoom>no</thumbZoom>
+          <spinPosX>1828</spinPosX>
+          <spinPosY>1000</spinPosY>
+          <unfocusedAlpha>100</unfocusedAlpha>
+        </control>
+
+        <control>
+          <description>Cover Flow view</description>
+          <type>coverflow</type>
+          <colordiffuse>90ffffff</colordiffuse>
+          <dimColor>90ffffff</dimColor>
+          <id>50</id>
+          <onup>2</onup>
+          <ondown>2</ondown>
+          <onleft>50</onleft>
+          <onright>50</onright>
+          <posX>0</posX>
+          <posY>595</posY>
+          <width>1920</width>
+          <height>340</height>
+          <selectedCard>0</selectedCard>
+          <cardWidth>238</cardWidth>
+          <cardHeight>340</cardHeight>
+          <angle>55</angle>
+          <sideShift>150</sideShift>
+          <sideGap>120</sideGap>
+          <sideDepth>110</sideDepth>
+          <offsetY>0</offsetY>
+          <selectedOffsetY>0</selectedOffsetY>
+          <speed>10</speed>
+          <showFrame>yes</showFrame>
+          <frame>-</frame>
+          <frameFocus>-</frameFocus>
+          <keepaspectratio>no</keepaspectratio>
+          <frameWidth>238</frameWidth>
+          <frameHeight>340</frameHeight>
+          <spinSpeed>8</spinSpeed>
+          <unfocusedAlpha>FF</unfocusedAlpha>
+          <folderPrefix></folderPrefix>
+          <folderSuffix></folderSuffix>
+          <font1>font13</font1>
+          <font2>font11</font2>
+          <label1>#title</label1>
+          <label2>#genre</label2>
+          <textColor>FFFFFFFF</textColor>
+          <remoteColor>FFFF0000</remoteColor>
+          <playedColor>FFA0D0FF</playedColor>
+          <downloadColor>FF00FF00</downloadColor>
+          <selectedColor>FFFFFFFF</selectedColor>
+          <shadowAngle>45</shadowAngle>
+          <shadowDistance>1</shadowDistance>
+          <shadowColor>FF000000</shadowColor>
+          <label1YOff>1430</label1YOff>
+          <label2YOff>1390</label2YOff>
+          <pageSize>5</pageSize>
+          <scrollbarBackground>scrollbar_bg_hor.png</scrollbarBackground>
+          <scrollbarLeft>scrollbar_left_hor.png</scrollbarLeft>
+          <scrollbarRight>scrollbar_right_hor.png</scrollbarRight>
+          <scrollbarWidth>717</scrollbarWidth>
+          <scrollbarHeight>8</scrollbarHeight>
+          <scrollbarYOff>375</scrollbarYOff>
+          <cards flipY="true" diffuse="Thumb_Mask_test.png" mask="filmstrip_mask.png"></cards>
+        </control>
+      </control>
+    </control>
+
+    <!--            :: HIDDEN MENU ::           	 -->
+
+    <control>
+      <id>1</id>
+      <type>image</type>
+      <posX>0</posX>
+      <posY>440</posY>
+      <width>64</width>
+      <height>199</height>
+      <texture>hiddenmenu_tab.png</texture>
+      <visible>[facadeview.list | facadeview.smallicons | facadeview.largeicons]+Control.HasFocus(50) + !string.contains(#Titan.HiddenMenu, false)</visible>
+      <animation effect="slide" start="-60,0" end="0,0" tween="quadratic" easing="in" time="250" delay="400">WindowOpen</animation>
+      <animation effect="slide" start="0,0" end="-60,0" tween="quadratic" easing="in" time="250" delay="100">WindowClose</animation>
+    </control>
+
+    <control>
+      <id>1</id>
+      <type>image</type>
+      <posX>858</posX>
+      <posY>0</posY>
+      <texture>hiddenmenu_tab_up.png</texture>
+      <visible>[facadeview.filmstrip | facadeview.coverflow] + Control.HasFocus(50) + !string.contains(#Titan.HiddenMenu, false)</visible>
+      <animation effect="slide" start="0,-60" end="0,0" tween="quadratic" easing="in" time="250" delay="400">WindowOpen</animation>
+      <animation effect="slide" start="0,0" end="0,-60" tween="quadratic" easing="in" time="250" delay="100">WindowClose</animation>
+    </control>
+
+    <control>
+      <type>actiongroup</type>
+      <description>action menu</description>
+      <defaultcontrol>3</defaultcontrol>
+      <onexit>50</onexit>
+      <dimColor>00ffffff</dimColor>
+      <buttonX>-460</buttonX>
+      <buttonY>155</buttonY>
+      <buttonwidth>499</buttonwidth>
+      <buttonheight>1080</buttonheight>
+
+      <control>
+        <type>image</type>
+        <id>0</id>
+        <width>1920</width>
+        <height>1080</height>
+        <texture>semi_trans_back_hidden_menu.png</texture>
+        <visible>!Control.HasFocus(50)+control.isvisible(50)</visible>
+        <animation effect="fade" time="450">visible</animation>
+        <animation effect="fade" time="400">hidden</animation>
+      </control>
+
+      <control>
+        <type>image</type>
+        <id>0</id>
+        <posY>0</posY>
+        <posX>0</posX>
+        <width>612</width>
+        <height>1074</height>
+        <texture>menu_bg.png</texture>
+        <visible>!Control.HasFocus(50)+control.isvisible(50)</visible>
+        <animation effect="fade" time="0">WindowClose</animation>
+        <animation effect="slide" start="-150,0" time="100">visible</animation>
+        <animation effect="fade" time="50">visible</animation>
+        <animation effect="fade" time="0">hidden</animation>
+      </control>
+      <control>
+        <description>Menu label</description>
+        <type>label</type>
+        <id>1</id>
+        <posX>116</posX>
+        <posY>100</posY>
+        <label>924</label>
+        <font>fontB16</font>
+        <textcolor>393939</textcolor>
+        <visible>!Control.HasFocus(50)+control.isvisible(50)</visible>
+        <animation effect="fade" time="0">WindowClose</animation>
+        <animation effect="slide" start="-150,0" time="100">visible</animation>
+        <animation effect="fade" time="50">visible</animation>
+        <animation effect="fade" time="0">hidden</animation>
+      </control>
+      <control>
+        <type>group</type>
+        <description>group element</description>
+        <visible>!Control.HasFocus(50)+control.isvisible(50)</visible>
+        <animation effect="fade" time="0">WindowClose</animation>
+        <animation effect="slide" start="-150,0" time="100">visible</animation>
+        <animation effect="fade" time="50">visible</animation>
+        <animation effect="fade" time="0">hidden</animation>
+        <posX>53</posX>
+        <posY>155</posY>
+        <layout>StackLayout(0, Vertical, true)</layout>
+
+        <control>
+          <description>Change Layout</description>
+          <type>button</type>
+          <id>2</id>
+          <textureFocus>hiddenmenu_item_selected.png</textureFocus>
+          <textureNoFocus>-</textureNoFocus>
+          <width>499</width>
+          <height>69</height>
+          <textXOff>62</textXOff>
+          <textYOff>16</textYOff>
+          <label>-</label>
+          <onright>50</onright>
+          <ondown>8</ondown>
+          <onup>10</onup>
+        </control>
+
+        <control>
+          <description>Sort</description>
+          <type>sortbutton</type>
+          <id>8</id>
+          <label>-</label>
+          <textureFocus>hiddenmenu_item_selected.png</textureFocus>
+          <textureNoFocus>-</textureNoFocus>
+          <width>499</width>
+          <height>69</height>
+          <textXOff>62</textXOff>
+          <textYOff>16</textYOff>
+          <offsetSortButtonX>421</offsetSortButtonX>
+          <offsetSortButtonY>27</offsetSortButtonY>
+          <onright>50</onright>
+          <onleft>50</onleft>
+          <ondown>10</ondown>
+          <onup>2</onup>
+        </control>
+
+        <control>
+          <description>Hide Watchlisted</description>
+          <type>checkbutton</type>
+          <id>10</id>
+          <width>499</width>
+          <height>69</height>
+          <textureFocus>hiddenmenu_item_selected.png</textureFocus>
+          <textureNoFocus>-</textureNoFocus>
+          <label>#Trakt.Translation.HideWatchlisted.Label</label>
+          <textcolorNoFocus>ff393939</textcolorNoFocus>
+          <onup>8</onup>
+          <ondown>11</ondown>
+          <onright>50</onright>
+          <onleft>50</onleft>
+          <textXOff>62</textXOff>
+          <textYOff>16</textYOff>
+        </control>
+
+      </control>
+    </control>
+    <import>Trakt.Common.Shows.xml</import>
+    <import>common.overlay.xml</import>
+  </controls>
+</window>

--- a/Common/Trakt.BoxOffice.xml
+++ b/Common/Trakt.BoxOffice.xml
@@ -1,0 +1,422 @@
+<?xml version="1.0" encoding="utf-8" standalone="yes"?>
+<window>
+  <id>87607</id>
+  <defaultcontrol>50</defaultcontrol>
+  <allowoverlay>no</allowoverlay>
+  <define>#Fanart.1:#Trakt.BoxOffice.Fanart.1</define>
+  <define>#Fanart.2:#Trakt.BoxOffice.Fanart.2</define>
+  <define>#header.label:#Trakt.Translation.BoxOffice.Label</define>
+  <controls>
+  <!-- #fanarthandler.movie.genres.selected -->
+    <control>
+      <description>DEFAULT BACKGROUND</description>
+      <type>image</type>
+      <id>0</id>
+      <posX>0</posX>
+      <posY>0</posY>
+      <width>1920</width>
+      <height>1080</height>
+      <texture>background.png</texture>
+      <shouldCache>true</shouldCache>
+    </control>
+    <import>Trakt.Common.Fanart.xml</import>
+    <!--            :: BACKGROUNDS ::           	 -->
+    <control>
+      <description>background listview</description>
+      <type>image</type>
+      <id>0</id>
+      <posX>0</posX>
+      <posY>0</posY>
+      <width>1920</width>
+      <height>1080</height>
+      <texture>fanart_overlay.png</texture>
+      <visible>!Control.IsVisible(51)</visible>
+      <animation effect="fade" time="250">WindowOpen</animation>
+      <animation effect="fade" time="250">WindowClose</animation>
+    </control>
+    <control>
+      <description>background listview</description>
+      <type>image</type>
+      <id>0</id>
+      <posX>10</posX>
+      <posY>252</posY>
+      <width>1903</width>
+      <height>790</height>
+      <texture>panel_list.png</texture>
+      <visible>facadeview.list + Control.IsVisible(50)</visible>
+      <animation effect="fade" time="250">WindowOpen</animation>
+      <animation effect="fade" time="250">WindowClose</animation>
+    </control>
+    <control>
+      <description>background thumbs</description>
+      <type>image</type>
+      <id>0</id>
+      <posX>10</posX>
+      <posY>252</posY>
+      <width>1903</width>
+      <height>790</height>
+      <texture>panel_tvseries_widebanner.6x2.png</texture>
+      <visible>[facadeview.smallicons | facadeview.largeicons] + Control.IsVisible(50)</visible>
+      <animation effect="fade" time="250">WindowOpen</animation>
+      <animation effect="fade" time="250">WindowClose</animation>
+    </control>
+    <control>
+      <description>filmstrip overlay</description>
+      <type>image</type>
+      <id>0</id>
+      <posX>0</posX>
+      <posY>279</posY>
+      <width>1920</width>
+      <height>801</height>
+      <texture>filmstrip_overlay.png</texture>
+      <visible>[facadeview.filmstrip | facadeview.coverflow] + Control.IsVisible(50)</visible>
+      <animation effect="fade" time="250">WindowOpen</animation>
+      <animation effect="fade" time="250">WindowClose</animation>
+    </control>
+    <control>
+      <description>filmstrip overlay</description>
+      <type>image</type>
+      <id>0</id>
+      <posX>52</posX>
+      <posY>958</posY>
+      <width>1820</width>
+      <height>84</height>
+      <texture>BasicHomeSubBG.png</texture>
+      <visible>[facadeview.filmstrip | facadeview.coverflow] + Control.IsVisible(50)</visible>
+      <animation effect="fade" time="250">WindowOpen</animation>
+      <animation effect="fade" time="250">WindowClose</animation>
+    </control>
+    <control>
+      <id>0</id>
+      <type>image</type>
+      <posX>66</posX>
+      <posY>34</posY>
+      <width>61</width>
+      <height>60</height>
+      <texture>icon_movies.png</texture>
+      <animation effect="fade" time="250">WindowOpen</animation>
+      <animation effect="fade" time="250">WindowClose</animation>
+    </control>
+    <import>common.time.xml</import>
+    <control>
+      <description>Total Revenue</description>
+      <type>label</type>
+      <label>#Trakt.Translation.TotalRevenue.Label: #Trakt.BoxOffice.Total.Revenue</label>
+      <id>0</id>
+      <posX>144</posX>
+      <posY>94</posY>
+      <width>1100</width>
+      <align>left</align>
+      <textcolor>FFFFFFFF</textcolor>
+      <font>TitanLight12</font>
+      <animation effect="fade" time="250">WindowOpen</animation>
+      <animation effect="fade" time="250">WindowClose</animation>
+    </control>
+    <!--            :: Count ::            -->
+    <control>
+      <description>Moviecount</description>
+      <type>label</type>
+      <label>#Trakt.Translation.Movies.Label: #itemcount</label>
+      <id>0</id>
+      <posX>96</posX>
+      <posY>998</posY>
+      <align>left</align>
+      <font>TitanLight12</font>
+      <textcolor>000000</textcolor>
+      <visible>[facadeview.list | facadeview.smallicons | facadeview.largeicons | facadeview.filmstrip | facadeview.coverflow] + control.isvisible(50)</visible>
+      <animation effect="fade" time="250">WindowOpen</animation>
+      <animation effect="fade" time="250">WindowClose</animation>
+    </control>
+    <!--            :: Listview Lines ::            -->
+    <control>
+      <description>List Lines</description>
+      <type>image</type>
+      <id>1</id>
+      <posX>1222</posX>
+      <posY>385</posY>
+      <width>607</width>
+      <height>506</height>
+      <texture>list_lines.png</texture>
+      <visible>facadeview.list + control.isvisible(50)</visible>
+      <animation effect="fade" time="250">WindowOpen</animation>
+      <animation effect="fade" time="250">WindowClose</animation>
+    </control>
+    <control>
+      <description>group element</description>
+      <type>group</type>
+      <animation effect="fade" time="250">WindowOpen</animation>
+      <animation effect="fade" time="250">WindowClose</animation>
+      <control>
+        <type>facadeview</type>
+        <id>50</id>
+        <control>
+          <description>Movie List</description>
+          <type>listcontrol</type>
+          <id>50</id>
+          <onleft>2</onleft>
+          <onright>2</onright>
+          <scrollOffset>1</scrollOffset>
+          <posX>1165</posX>
+          <posY>331</posY>
+          <height>700</height>
+          <width>698</width>
+          <textXOff>44</textXOff>
+          <textXOff2>650</textXOff2>
+          <textureHeight>54</textureHeight>
+          <textureFocus>listcontrol_item_selected.png</textureFocus>
+          <textureNoFocus>-</textureNoFocus>
+          <dimColor>ffffffff</dimColor>
+          <spinPosX>1828</spinPosX>
+          <spinPosY>1000</spinPosY>
+        </control>
+        <control>
+          <description>Filmstrip view</description>
+          <type>filmstrip</type>
+          <dimColor>90ffffff</dimColor>
+          <id>50</id>
+          <scrollOffset>3</scrollOffset>
+          <folderPrefix></folderPrefix>
+          <folderSuffix></folderSuffix>
+          <posX>130</posX>
+          <posY>595</posY>
+          <width>1700</width>
+          <height>340</height>
+          <onup>2</onup>
+          <ondown>2</ondown>
+          <onleft>50</onleft>
+          <onright>50</onright>
+          <thumbWidth>230</thumbWidth>
+          <thumbHeight>327</thumbHeight>
+          <thumbPosX>0</thumbPosX>
+          <thumbPosY>0</thumbPosY>
+          <itemWidth>240</itemWidth>
+          <itemHeight>327</itemHeight>
+          <textureWidth>230</textureWidth>
+          <textureHeight>327</textureHeight>
+          <textYOff>-2000</textYOff>
+          <imageFolderFocus>-</imageFolderFocus>
+          <frame>-</frame>
+          <frameFocus>-</frameFocus>
+          <background>-</background>
+          <thumbs flipY="true" diffuse="Thumb_Mask_test.png" mask="filmstrip_mask.png"></thumbs>
+          <showFrame>yes</showFrame>
+          <showFolder>no</showFolder>
+          <showBackGround>no</showBackGround>
+          <showInfoImage>no</showInfoImage>
+          <scrollbarBackground>scrollbar_bg_hor.png</scrollbarBackground>
+          <scrollbarLeft>scrollbar_left_hor.png</scrollbarLeft>
+          <scrollbarRight>scrollbar_right_hor.png</scrollbarRight>
+          <scrollbarWidth>717</scrollbarWidth>
+          <scrollbarHeight>8</scrollbarHeight>
+          <scrollbarYOff>375</scrollbarYOff>
+          <keepaspectratio>no</keepaspectratio>
+          <thumbAnimation effect="zoom" acceleration="-2" start="100,100" reversible="false" end="120,120" center="0,880" time="200">focus</thumbAnimation>
+          <thumbAnimation effect="zoom" start="120,120" reversible="false" end="100,100" center="0,880" time="100">unfocus</thumbAnimation>
+        </control>
+        <control>
+          <description>Thumbnail Panel</description>
+          <type>thumbnailpanel</type>
+          <id>50</id>
+          <posX>754</posX>
+          <posY>342</posY>
+          <width>1150</width>
+          <height>700</height>
+          <folderPrefix></folderPrefix>
+          <folderSuffix></folderSuffix>
+          <onleft>2</onleft>
+          <onright>2</onright>
+          <itemWidth>138</itemWidth>
+          <itemHeight>196</itemHeight>
+          <textureWidth>138</textureWidth>
+          <textureHeight>196</textureHeight>
+          <thumbWidth>128</thumbWidth>
+          <thumbHeight>186</thumbHeight>
+          <thumbPosX>6</thumbPosX>
+          <thumbPosY>5</thumbPosY>
+          <itemWidthBig>214</itemWidthBig>
+          <itemHeightBig>304</itemHeightBig>
+          <thumbWidthBig>204</thumbWidthBig>
+          <thumbHeightBig>294</thumbHeightBig>
+          <textureWidthBig>216</textureWidthBig>
+          <textureHeightBig>304</textureHeightBig>
+          <thumbPosXBig>6</thumbPosXBig>
+          <thumbPosYBig>5</thumbPosYBig>
+          <zoomXPixels>0</zoomXPixels>
+          <zoomYPixels>0</zoomYPixels>
+          <hideUnfocusTexture>no</hideUnfocusTexture>
+          <keepaspectratio>no</keepaspectratio>
+          <renderFocusText>no</renderFocusText>
+          <renderUnfocusText>no</renderUnfocusText>
+          <frameNoFocus>-</frameNoFocus>
+          <frameFocus>video_thumb_focus.png</frameFocus>
+          <textureMask></textureMask>
+          <shadowAngle>90</shadowAngle>
+          <shadowDistance>50</shadowDistance>
+          <thumbZoom>no</thumbZoom>
+          <spinPosX>1828</spinPosX>
+          <spinPosY>1000</spinPosY>
+          <unfocusedAlpha>100</unfocusedAlpha>
+        </control>
+        <control>
+          <description>Cover Flow view</description>
+          <type>coverflow</type>
+          <colordiffuse>90ffffff</colordiffuse>
+          <dimColor>90ffffff</dimColor>
+          <id>50</id>
+          <onup>2</onup>
+          <ondown>2</ondown>
+          <onleft>50</onleft>
+          <onright>50</onright>
+          <posX>0</posX>
+          <posY>595</posY>
+          <width>1920</width>
+          <height>340</height>
+          <selectedCard>0</selectedCard>
+          <cardWidth>238</cardWidth>
+          <cardHeight>340</cardHeight>
+          <angle>55</angle>
+          <sideShift>150</sideShift>
+          <sideGap>120</sideGap>
+          <sideDepth>110</sideDepth>
+          <offsetY>0</offsetY>
+          <selectedOffsetY>0</selectedOffsetY>
+          <speed>10</speed>
+          <showFrame>yes</showFrame>
+          <frame>-</frame>
+          <frameFocus>-</frameFocus>
+          <keepaspectratio>no</keepaspectratio>
+          <frameWidth>238</frameWidth>
+          <frameHeight>340</frameHeight>
+          <spinSpeed>8</spinSpeed>
+          <unfocusedAlpha>FF</unfocusedAlpha>
+          <folderPrefix></folderPrefix>
+          <folderSuffix></folderSuffix>
+          <font1>font13</font1>
+          <font2>font11</font2>
+          <label1>#title</label1>
+          <label2>#genre</label2>
+          <textColor>FFFFFFFF</textColor>
+          <remoteColor>FFFF0000</remoteColor>
+          <playedColor>FFA0D0FF</playedColor>
+          <downloadColor>FF00FF00</downloadColor>
+          <selectedColor>FFFFFFFF</selectedColor>
+          <shadowAngle>45</shadowAngle>
+          <shadowDistance>1</shadowDistance>
+          <shadowColor>FF000000</shadowColor>
+          <label1YOff>1430</label1YOff>
+          <label2YOff>1390</label2YOff>
+          <pageSize>5</pageSize>
+          <scrollbarBackground>scrollbar_bg_hor.png</scrollbarBackground>
+          <scrollbarLeft>scrollbar_left_hor.png</scrollbarLeft>
+          <scrollbarRight>scrollbar_right_hor.png</scrollbarRight>
+          <scrollbarWidth>717</scrollbarWidth>
+          <scrollbarHeight>8</scrollbarHeight>
+          <scrollbarYOff>375</scrollbarYOff>
+          <cards flipY="true" diffuse="Thumb_Mask_test.png" mask="filmstrip_mask.png"></cards>
+        </control>
+      </control>
+    </control>
+    <!--            :: HIDDEN MENU ::           	 -->
+    <control>
+      <id>1</id>
+      <type>image</type>
+      <posX>0</posX>
+      <posY>440</posY>
+      <width>64</width>
+      <height>199</height>
+      <texture>hiddenmenu_tab.png</texture>
+      <visible>[facadeview.list | facadeview.smallicons | facadeview.largeicons]+Control.HasFocus(50) + !string.contains(#Titan.HiddenMenu, false)</visible>
+      <animation effect="slide" start="-60,0" end="0,0" tween="quadratic" easing="in" time="250" delay="400">WindowOpen</animation>
+      <animation effect="slide" start="0,0" end="-60,0" tween="quadratic" easing="in" time="250" delay="100">WindowClose</animation>
+    </control>
+    <control>
+      <id>1</id>
+      <type>image</type>
+      <posX>858</posX>
+      <posY>0</posY>
+      <texture>hiddenmenu_tab_up.png</texture>
+      <visible>[facadeview.filmstrip | facadeview.coverflow] + Control.HasFocus(50) + !string.contains(#Titan.HiddenMenu, false)</visible>
+      <animation effect="slide" start="0,-60" end="0,0" tween="quadratic" easing="in" time="250" delay="400">WindowOpen</animation>
+      <animation effect="slide" start="0,0" end="0,-60" tween="quadratic" easing="in" time="250" delay="100">WindowClose</animation>
+    </control>
+    <control>
+      <type>actiongroup</type>
+      <description>action menu</description>
+      <defaultcontrol>3</defaultcontrol>
+      <onexit>50</onexit>
+      <dimColor>00ffffff</dimColor>
+      <buttonX>-460</buttonX>
+      <buttonY>155</buttonY>
+      <buttonwidth>499</buttonwidth>
+      <buttonheight>1080</buttonheight>
+      <control>
+        <type>image</type>
+        <id>0</id>
+        <width>1920</width>
+        <height>1080</height>
+        <texture>semi_trans_back_hidden_menu.png</texture>
+        <visible>!Control.HasFocus(50)+control.isvisible(50)</visible>
+        <animation effect="fade" time="450">visible</animation>
+        <animation effect="fade" time="400">hidden</animation>
+      </control>
+      <control>
+        <type>image</type>
+        <id>0</id>
+        <posY>0</posY>
+        <posX>0</posX>
+        <width>612</width>
+        <height>1074</height>
+        <texture>menu_bg.png</texture>
+        <visible>!Control.HasFocus(50)+control.isvisible(50)</visible>
+        <animation effect="fade" time="0">WindowClose</animation>
+        <animation effect="slide" start="-150,0" time="100">visible</animation>
+        <animation effect="fade" time="50">visible</animation>
+        <animation effect="fade" time="0">hidden</animation>
+      </control>
+      <control>
+        <description>Menu label</description>
+        <type>label</type>
+        <id>1</id>
+        <posX>116</posX>
+        <posY>100</posY>
+        <label>924</label>
+        <font>fontB16</font>
+        <textcolor>393939</textcolor>
+        <visible>!Control.HasFocus(50)+control.isvisible(50)</visible>
+        <animation effect="fade" time="0">WindowClose</animation>
+        <animation effect="slide" start="-150,0" time="100">visible</animation>
+        <animation effect="fade" time="50">visible</animation>
+        <animation effect="fade" time="0">hidden</animation>
+      </control>
+      <control>
+        <type>group</type>
+        <description>group element</description>
+        <visible>!Control.HasFocus(50)+control.isvisible(50)</visible>
+        <animation effect="fade" time="0">WindowClose</animation>
+        <animation effect="slide" start="-150,0" time="100">visible</animation>
+        <animation effect="fade" time="50">visible</animation>
+        <animation effect="fade" time="0">hidden</animation>
+        <posX>53</posX>
+        <posY>155</posY>
+        <layout>StackLayout(0, Vertical, true)</layout>
+        <control>
+          <description>Change Layout</description>
+          <type>button</type>
+          <id>2</id>
+          <textureFocus>hiddenmenu_item_selected.png</textureFocus>
+          <textureNoFocus>-</textureNoFocus>
+          <width>499</width>
+          <height>69</height>
+          <textXOff>62</textXOff>
+          <textYOff>16</textYOff>
+          <label>-</label>
+          <onright>50</onright>
+          <ondown>8</ondown>
+          <onup>8</onup>
+        </control>
+      </control>
+    </control>
+    <import>Trakt.Common.Movies.xml</import>
+    <import>common.overlay.xml</import>
+  </controls>
+</window>

--- a/Common/Trakt.Calendar.Movies.xml
+++ b/Common/Trakt.Calendar.Movies.xml
@@ -1,0 +1,451 @@
+<?xml version="1.0" encoding="utf-8" standalone="yes"?>
+<window>
+  <id>87700</id>
+  <defaultcontrol>50</defaultcontrol>
+  <allowoverlay>no</allowoverlay>
+  <define>#Fanart.1:#Trakt.CalendarMovies.Fanart.1</define>
+  <define>#Fanart.2:#Trakt.CalendarMovies.Fanart.2</define>
+  <define>#header.label:#Trakt.Translation.Calendar.Label</define>
+  <controls>
+  <!-- #fanarthandler.movie.genres.selected -->
+    <control>
+      <description>DEFAULT BACKGROUND</description>
+      <type>image</type>
+      <id>0</id>
+      <posX>0</posX>
+      <posY>0</posY>
+      <width>1920</width>
+      <height>1080</height>
+      <texture>background.png</texture>
+      <shouldCache>true</shouldCache>
+    </control>
+    <import>Trakt.Common.Fanart.xml</import>
+    <!--            :: BACKGROUNDS ::           	 -->
+    <control>
+      <description>background listview</description>
+      <type>image</type>
+      <id>0</id>
+      <posX>0</posX>
+      <posY>0</posY>
+      <width>1920</width>
+      <height>1080</height>
+      <texture>fanart_overlay.png</texture>
+      <visible>!Control.IsVisible(51)</visible>
+      <animation effect="fade" time="250">WindowOpen</animation>
+      <animation effect="fade" time="250">WindowClose</animation>
+    </control>
+    <control>
+      <description>background listview</description>
+      <type>image</type>
+      <id>0</id>
+      <posX>10</posX>
+      <posY>252</posY>
+      <width>1903</width>
+      <height>790</height>
+      <texture>panel_list.png</texture>
+      <visible>facadeview.list + Control.IsVisible(50)</visible>
+      <animation effect="fade" time="250">WindowOpen</animation>
+      <animation effect="fade" time="250">WindowClose</animation>
+    </control>
+    <control>
+      <description>background thumbs</description>
+      <type>image</type>
+      <id>0</id>
+      <posX>10</posX>
+      <posY>252</posY>
+      <width>1903</width>
+      <height>790</height>
+      <texture>panel_tvseries_widebanner.6x2.png</texture>
+      <visible>[facadeview.smallicons | facadeview.largeicons] + Control.IsVisible(50)</visible>
+      <animation effect="fade" time="250">WindowOpen</animation>
+      <animation effect="fade" time="250">WindowClose</animation>
+    </control>
+    <control>
+      <description>filmstrip overlay</description>
+      <type>image</type>
+      <id>0</id>
+      <posX>0</posX>
+      <posY>279</posY>
+      <width>1920</width>
+      <height>801</height>
+      <texture>filmstrip_overlay.png</texture>
+      <visible>[facadeview.filmstrip | facadeview.coverflow] + Control.IsVisible(50)</visible>
+      <animation effect="fade" time="250">WindowOpen</animation>
+      <animation effect="fade" time="250">WindowClose</animation>
+    </control>
+    <control>
+      <description>filmstrip overlay</description>
+      <type>image</type>
+      <id>0</id>
+      <posX>52</posX>
+      <posY>958</posY>
+      <width>1820</width>
+      <height>84</height>
+      <texture>BasicHomeSubBG.png</texture>
+      <visible>[facadeview.filmstrip | facadeview.coverflow] + Control.IsVisible(50)</visible>
+      <animation effect="fade" time="250">WindowOpen</animation>
+      <animation effect="fade" time="250">WindowClose</animation>
+    </control>
+    <control>
+      <id>0</id>
+      <type>image</type>
+      <posX>66</posX>
+      <posY>34</posY>
+      <width>61</width>
+      <height>60</height>
+      <texture>icon_movies.png</texture>
+      <animation effect="fade" time="250">WindowOpen</animation>
+      <animation effect="fade" time="250">WindowClose</animation>
+    </control>
+    <import>common.time.xml</import>
+	<control>
+      <description>View</description>
+      <type>label</type>
+      <label>#Trakt.CurrentView</label>
+      <id>0</id>
+      <posX>144</posX>
+      <posY>94</posY>
+      <width>1100</width>
+      <align>left</align>
+      <textcolor>FFFFFFFF</textcolor>
+      <font>TitanLight12</font>
+      <animation effect="fade" time="250">WindowOpen</animation>
+      <animation effect="fade" time="250">WindowClose</animation>
+    </control>
+    
+    <!--            :: Count ::            -->
+    <control>
+      <description>Moviecount</description>
+      <type>label</type>
+      <label>#Trakt.Translation.Movies.Label: #itemcount</label>
+      <id>0</id>
+      <posX>96</posX>
+      <posY>998</posY>
+      <align>left</align>
+      <font>TitanLight12</font>
+      <textcolor>000000</textcolor>
+      <visible>[facadeview.list | facadeview.smallicons | facadeview.largeicons | facadeview.filmstrip | facadeview.coverflow] + control.isvisible(50)</visible>
+      <animation effect="fade" time="250">WindowOpen</animation>
+      <animation effect="fade" time="250">WindowClose</animation>
+    </control>
+    <!--            :: Listview Lines ::            -->
+    <control>
+      <description>List Lines</description>
+      <type>image</type>
+      <id>1</id>
+      <posX>1222</posX>
+      <posY>385</posY>
+      <width>607</width>
+      <height>506</height>
+      <texture>list_lines.png</texture>
+      <visible>facadeview.list + control.isvisible(50)</visible>
+      <animation effect="fade" time="250">WindowOpen</animation>
+      <animation effect="fade" time="250">WindowClose</animation>
+    </control>
+    <control>
+      <description>group element</description>
+      <type>group</type>
+      <animation effect="fade" time="250">WindowOpen</animation>
+      <animation effect="fade" time="250">WindowClose</animation>
+      <control>
+        <type>facadeview</type>
+        <id>50</id>
+        <control>
+			<description>Calendar List</description>
+			<type>listcontrol</type>
+			<id>50</id>
+			<onleft>2</onleft>
+			<onright>2</onright>
+			<scrollOffset>1</scrollOffset>
+			<posX>1165</posX>
+			<posY>331</posY>
+			<height>800</height>
+			<width>780</width>
+			<height>700</height>
+            <width>698</width>
+            <textXOff>44</textXOff>
+            <textXOff2>650</textXOff2>
+			<textXOff3>54</textXOff3>
+			<textcolor>FFFFFFFF</textcolor>
+			<textcolor2>FFFFFFFF</textcolor2>
+			<textcolor3>FF00b7ff</textcolor3>
+			<font3>fontB12</font3>
+			<textureHeight>54</textureHeight>
+			<textureFocus>listcontrol_item_selected_trakt.png</textureFocus>
+			<textureNoFocus>-</textureNoFocus>
+			<dimColor>ffffffff</dimColor>
+			<spinPosX>1828</spinPosX>
+			<spinPosY>1000</spinPosY>
+			<explicitlyEnableScrollLabel>no</explicitlyEnableScrollLabel>
+        </control>
+        <control>
+          <description>Filmstrip view</description>
+          <type>filmstrip</type>
+          <dimColor>90ffffff</dimColor>
+          <id>50</id>
+          <scrollOffset>3</scrollOffset>
+          <folderPrefix></folderPrefix>
+          <folderSuffix></folderSuffix>
+          <posX>130</posX>
+          <posY>595</posY>
+          <width>1700</width>
+          <height>340</height>
+          <onup>2</onup>
+          <ondown>2</ondown>
+          <onleft>50</onleft>
+          <onright>50</onright>
+          <thumbWidth>230</thumbWidth>
+          <thumbHeight>327</thumbHeight>
+          <thumbPosX>0</thumbPosX>
+          <thumbPosY>0</thumbPosY>
+          <itemWidth>240</itemWidth>
+          <itemHeight>327</itemHeight>
+          <textureWidth>230</textureWidth>
+          <textureHeight>327</textureHeight>
+          <textYOff>-2000</textYOff>
+          <imageFolderFocus>-</imageFolderFocus>
+          <frame>-</frame>
+          <frameFocus>-</frameFocus>
+          <background>-</background>
+          <thumbs flipY="true" diffuse="Thumb_Mask_test.png" mask="filmstrip_mask.png"></thumbs>
+          <showFrame>yes</showFrame>
+          <showFolder>no</showFolder>
+          <showBackGround>no</showBackGround>
+          <showInfoImage>no</showInfoImage>
+          <scrollbarBackground>scrollbar_bg_hor.png</scrollbarBackground>
+          <scrollbarLeft>scrollbar_left_hor.png</scrollbarLeft>
+          <scrollbarRight>scrollbar_right_hor.png</scrollbarRight>
+          <scrollbarWidth>717</scrollbarWidth>
+          <scrollbarHeight>8</scrollbarHeight>
+          <scrollbarYOff>375</scrollbarYOff>
+          <keepaspectratio>no</keepaspectratio>
+          <thumbAnimation effect="zoom" acceleration="-2" start="100,100" reversible="false" end="120,120" center="0,880" time="200">focus</thumbAnimation>
+          <thumbAnimation effect="zoom" start="120,120" reversible="false" end="100,100" center="0,880" time="100">unfocus</thumbAnimation>
+        </control>
+        <control>
+          <description>Thumbnail Panel</description>
+          <type>thumbnailpanel</type>
+          <id>50</id>
+          <posX>754</posX>
+          <posY>342</posY>
+          <width>1150</width>
+          <height>700</height>
+          <folderPrefix></folderPrefix>
+          <folderSuffix></folderSuffix>
+          <onleft>2</onleft>
+          <onright>2</onright>
+          <itemWidth>138</itemWidth>
+          <itemHeight>196</itemHeight>
+          <textureWidth>138</textureWidth>
+          <textureHeight>196</textureHeight>
+          <thumbWidth>128</thumbWidth>
+          <thumbHeight>186</thumbHeight>
+          <thumbPosX>6</thumbPosX>
+          <thumbPosY>5</thumbPosY>
+          <itemWidthBig>214</itemWidthBig>
+          <itemHeightBig>304</itemHeightBig>
+          <thumbWidthBig>204</thumbWidthBig>
+          <thumbHeightBig>294</thumbHeightBig>
+          <textureWidthBig>216</textureWidthBig>
+          <textureHeightBig>304</textureHeightBig>
+          <thumbPosXBig>6</thumbPosXBig>
+          <thumbPosYBig>5</thumbPosYBig>
+          <zoomXPixels>0</zoomXPixels>
+          <zoomYPixels>0</zoomYPixels>
+          <hideUnfocusTexture>no</hideUnfocusTexture>
+          <keepaspectratio>no</keepaspectratio>
+          <renderFocusText>no</renderFocusText>
+          <renderUnfocusText>no</renderUnfocusText>
+          <frameNoFocus>-</frameNoFocus>
+          <frameFocus>video_thumb_focus.png</frameFocus>
+          <textureMask></textureMask>
+          <shadowAngle>90</shadowAngle>
+          <shadowDistance>50</shadowDistance>
+          <thumbZoom>no</thumbZoom>
+          <spinPosX>1828</spinPosX>
+          <spinPosY>1000</spinPosY>
+          <unfocusedAlpha>100</unfocusedAlpha>
+        </control>
+        <control>
+          <description>Cover Flow view</description>
+          <type>coverflow</type>
+          <colordiffuse>90ffffff</colordiffuse>
+          <dimColor>90ffffff</dimColor>
+          <id>50</id>
+          <onup>2</onup>
+          <ondown>2</ondown>
+          <onleft>50</onleft>
+          <onright>50</onright>
+          <posX>0</posX>
+          <posY>595</posY>
+          <width>1920</width>
+          <height>340</height>
+          <selectedCard>0</selectedCard>
+          <cardWidth>238</cardWidth>
+          <cardHeight>340</cardHeight>
+          <angle>55</angle>
+          <sideShift>150</sideShift>
+          <sideGap>120</sideGap>
+          <sideDepth>110</sideDepth>
+          <offsetY>0</offsetY>
+          <selectedOffsetY>0</selectedOffsetY>
+          <speed>10</speed>
+          <showFrame>yes</showFrame>
+          <frame>-</frame>
+          <frameFocus>-</frameFocus>
+          <keepaspectratio>no</keepaspectratio>
+          <frameWidth>238</frameWidth>
+          <frameHeight>340</frameHeight>
+          <spinSpeed>8</spinSpeed>
+          <unfocusedAlpha>FF</unfocusedAlpha>
+          <folderPrefix></folderPrefix>
+          <folderSuffix></folderSuffix>
+          <font1>font13</font1>
+          <font2>font11</font2>
+          <label1>#title</label1>
+          <label2>#genre</label2>
+          <textColor>FFFFFFFF</textColor>
+          <remoteColor>FFFF0000</remoteColor>
+          <playedColor>FFA0D0FF</playedColor>
+          <downloadColor>FF00FF00</downloadColor>
+          <selectedColor>FFFFFFFF</selectedColor>
+          <shadowAngle>45</shadowAngle>
+          <shadowDistance>1</shadowDistance>
+          <shadowColor>FF000000</shadowColor>
+          <label1YOff>1430</label1YOff>
+          <label2YOff>1390</label2YOff>
+          <pageSize>5</pageSize>
+          <scrollbarBackground>scrollbar_bg_hor.png</scrollbarBackground>
+          <scrollbarLeft>scrollbar_left_hor.png</scrollbarLeft>
+          <scrollbarRight>scrollbar_right_hor.png</scrollbarRight>
+          <scrollbarWidth>717</scrollbarWidth>
+          <scrollbarHeight>8</scrollbarHeight>
+          <scrollbarYOff>375</scrollbarYOff>
+          <cards flipY="true" diffuse="Thumb_Mask_test.png" mask="filmstrip_mask.png"></cards>
+        </control>
+      </control>
+    </control>
+    <!--            :: HIDDEN MENU ::           	 -->
+    <control>
+      <id>1</id>
+      <type>image</type>
+      <posX>0</posX>
+      <posY>440</posY>
+      <width>64</width>
+      <height>199</height>
+      <texture>hiddenmenu_tab.png</texture>
+      <visible>Control.HasFocus(50) + !string.contains(#Titan.HiddenMenu, false)</visible>
+      <animation effect="slide" start="-60,0" end="0,0" tween="quadratic" easing="in" time="250" delay="400">WindowOpen</animation>
+      <animation effect="slide" start="0,0" end="-60,0" tween="quadratic" easing="in" time="250" delay="100">WindowClose</animation>
+    </control>
+    <control>
+      <type>actiongroup</type>
+      <description>action menu</description>
+      <defaultcontrol>3</defaultcontrol>
+      <onexit>50</onexit>
+      <dimColor>00ffffff</dimColor>
+      <buttonX>0</buttonX>
+      <buttonY>0</buttonY>
+      <buttonwidth>521</buttonwidth>
+      <buttonheight>1080</buttonheight>
+      <control>
+        <type>image</type>
+        <id>0</id>
+        <width>1920</width>
+        <height>1080</height>
+        <texture>semi_trans_back_hidden_menu.png</texture>
+        <visible>!Control.HasFocus(50)+control.isvisible(50)</visible>
+        <animation effect="fade" time="450">visible</animation>
+        <animation effect="fade" time="400">hidden</animation>
+      </control>
+      <control>
+        <type>image</type>
+        <id>0</id>
+        <posY>0</posY>
+        <posX>0</posX>
+        <width>612</width>
+        <height>1074</height>
+        <texture>menu_bg.png</texture>
+        <visible>!Control.HasFocus(50)+control.isvisible(50)</visible>
+        <animation effect="fade" time="0">WindowClose</animation>
+        <animation effect="slide" start="-150,0" time="100">visible</animation>
+        <animation effect="fade" time="50">visible</animation>
+        <animation effect="fade" time="0">hidden</animation>
+      </control>
+      <control>
+        <description>Menu label</description>
+        <type>label</type>
+        <id>1</id>
+        <posX>116</posX>
+        <posY>100</posY>
+        <label>924</label>
+        <font>fontB16</font>
+        <textcolor>393939</textcolor>
+        <visible>!Control.HasFocus(50)+control.isvisible(50)</visible>
+        <animation effect="fade" time="0">WindowClose</animation>
+        <animation effect="slide" start="-150,0" time="100">visible</animation>
+        <animation effect="fade" time="50">visible</animation>
+        <animation effect="fade" time="0">hidden</animation>
+      </control>
+      <control>
+        <type>group</type>
+        <description>group element</description>
+        <visible>!Control.HasFocus(50)+control.isvisible(50)</visible>
+        <animation effect="fade" time="0">WindowClose</animation>
+        <animation effect="slide" start="-150,0" time="100">visible</animation>
+        <animation effect="fade" time="50">visible</animation>
+        <animation effect="fade" time="0">hidden</animation>
+        <posX>53</posX>
+        <posY>155</posY>
+        <layout>StackLayout(0, Vertical, true)</layout>
+        <control>
+          <description>Change Layout</description>
+          <type>button</type>
+          <id>2</id>
+          <textureFocus>hiddenmenu_item_selected.png</textureFocus>
+          <textureNoFocus>-</textureNoFocus>
+          <width>499</width>
+          <height>69</height>
+          <textXOff>62</textXOff>
+          <textYOff>16</textYOff>
+          <label>-</label>
+          <onup>66612</onup>
+          <ondown>3</ondown>
+          <onright>50</onright>
+        </control>
+        <control>
+          <description>Start Date</description>
+          <type>button</type>
+          <id>3</id>
+          <textureFocus>hiddenmenu_item_selected.png</textureFocus>
+          <textureNoFocus>-</textureNoFocus>
+          <width>499</width>
+          <height>69</height>
+          <textXOff>62</textXOff>
+          <textYOff>16</textYOff>
+          <label>-</label>
+          <onup>2</onup>
+          <ondown>5</ondown>
+          <onright>50</onright>
+        </control>
+		<control>
+          <description>Max Days</description>
+          <type>button</type>
+          <id>5</id>
+          <textureFocus>hiddenmenu_item_selected.png</textureFocus>
+          <textureNoFocus>-</textureNoFocus>
+          <width>499</width>
+          <height>69</height>
+          <textXOff>62</textXOff>
+          <textYOff>16</textYOff>
+          <label>-</label>
+          <onup>3</onup>
+          <ondown>2</ondown>
+          <onright>50</onright>
+        </control>
+      </control>
+    </control>
+    <import>Trakt.Common.Movies.xml</import>
+    <import>common.overlay.xml</import>
+  </controls>
+</window>

--- a/Common/Trakt.Calendar.xml
+++ b/Common/Trakt.Calendar.xml
@@ -483,7 +483,7 @@
    		<posY>800</posY>
    		<width>250</width>
    		<height>140</height>
-		<texture>#fanarthandler.series.clearart.selected</texture>
+		<texture>#fanarthandler.tvseries.clearart.selected</texture>
         <animation effect="fade" time="250">WindowOpen</animation>
         <animation effect="fade" time="250">WindowClose</animation>
    	</control>  
@@ -498,7 +498,7 @@
    		<width>250</width>
    		<height>140</height>
     	<visible>!control.hasthumb(159357)</visible>
-		<texture>#fanarthandler.series.clearlogo.selected</texture>
+		<texture>#fanarthandler.tvseries.clearlogo.selected</texture>
         <animation effect="fade" time="250">WindowOpen</animation>
         <animation effect="fade" time="250">WindowClose</animation>
    	</control>  

--- a/Common/Trakt.Calendar.xml
+++ b/Common/Trakt.Calendar.xml
@@ -8,6 +8,7 @@
   <define>#header.hover:background.png</define>
   <define>#header.label:#Trakt.Translation.Calendar.Label</define>
   <controls>
+
     <control>
       <description>DEFAULT BACKGROUND</description>
       <type>image</type>
@@ -52,7 +53,7 @@
       <posY>34</posY>
       <width>61</width>
       <height>60</height>
-      <texture>icon_plugin.png</texture>
+      <texture>icon_series.png</texture>
       <animation effect="fade" time="250">WindowOpen</animation>
       <animation effect="fade" time="250">WindowClose</animation>
     </control>
@@ -482,7 +483,7 @@
    		<posY>800</posY>
    		<width>250</width>
    		<height>140</height>
-		<texture>..\..\..\Thumbs\ClearArt\Series\#(string.trim(#Trakt.Show.TvdbId)).png</texture>
+		<texture>#fanarthandler.series.clearart.selected</texture>
         <animation effect="fade" time="250">WindowOpen</animation>
         <animation effect="fade" time="250">WindowClose</animation>
    	</control>  
@@ -497,7 +498,7 @@
    		<width>250</width>
    		<height>140</height>
     	<visible>!control.hasthumb(159357)</visible>
-		<texture>..\..\..\Thumbs\ClearLogo\Series\#(string.trim(#Trakt.Show.TvdbId)).png</texture>
+		<texture>#fanarthandler.series.clearlogo.selected</texture>
         <animation effect="fade" time="250">WindowOpen</animation>
         <animation effect="fade" time="250">WindowClose</animation>
    	</control>  

--- a/Common/Trakt.Common.Episodes.xml
+++ b/Common/Trakt.Common.Episodes.xml
@@ -11,7 +11,7 @@
    		<posY>150</posY>
    		<width>250</width>
    		<height>140</height>
-		<texture>..\..\..\Thumbs\ClearArt\Series\#(string.trim(#Trakt.Show.TvdbId)).png</texture>
+		<texture>#fanarthandler.series.clearart.selected</texture>
         <animation effect="fade" time="250">WindowOpen</animation>
         <animation effect="fade" time="250">WindowClose</animation>
    	</control>  
@@ -26,7 +26,7 @@
    		<width>250</width>
    		<height>140</height>
     	<visible>!control.hasthumb(159357)</visible>
-		<texture>..\..\..\Thumbs\ClearLogo\Series\#(string.trim(#Trakt.Show.TvdbId)).png</texture>
+		<texture>#fanarthandler.series.clearlogo.selected</texture>
         <animation effect="fade" time="250">WindowOpen</animation>
         <animation effect="fade" time="250">WindowClose</animation>
    	</control>  

--- a/Common/Trakt.Common.Episodes.xml
+++ b/Common/Trakt.Common.Episodes.xml
@@ -11,7 +11,7 @@
    		<posY>150</posY>
    		<width>250</width>
    		<height>140</height>
-		<texture>#fanarthandler.series.clearart.selected</texture>
+		<texture>#fanarthandler.tvseries.clearart.selected</texture>
         <animation effect="fade" time="250">WindowOpen</animation>
         <animation effect="fade" time="250">WindowClose</animation>
    	</control>  
@@ -26,7 +26,7 @@
    		<width>250</width>
    		<height>140</height>
     	<visible>!control.hasthumb(159357)</visible>
-		<texture>#fanarthandler.series.clearlogo.selected</texture>
+		<texture>#fanarthandler.tvseries.clearlogo.selected</texture>
         <animation effect="fade" time="250">WindowOpen</animation>
         <animation effect="fade" time="250">WindowClose</animation>
    	</control>  

--- a/Common/Trakt.Common.Movies.xml
+++ b/Common/Trakt.Common.Movies.xml
@@ -11,7 +11,7 @@
        		<posY>150</posY>
        		<width>250</width>
        		<height>140</height>
-    		<texture>..\..\..\Thumbs\ClearArt\Movies\#(string.trim(#Trakt.Movie.ImdbId)).png</texture>
+    		<texture>#fanarthandler.movie.clearart.selected</texture>
             <animation effect="fade" time="250">WindowOpen</animation>
             <animation effect="fade" time="250">WindowClose</animation>
        	</control>  
@@ -26,7 +26,7 @@
        		<width>250</width>
        		<height>140</height>
         	<visible>!control.hasthumb(159357)</visible>
-    		<texture>..\..\..\Thumbs\ClearLogo\Movies\#(string.trim(#Trakt.Movie.ImdbId)).png</texture>
+    		<texture>#fanarthandler.movie.clearlogo.selected</texture>
             <animation effect="fade" time="250">WindowOpen</animation>
             <animation effect="fade" time="250">WindowClose</animation>
        	</control>  

--- a/Common/Trakt.Common.Shows.xml
+++ b/Common/Trakt.Common.Shows.xml
@@ -11,7 +11,7 @@
    		<posY>150</posY>
    		<width>250</width>
    		<height>140</height>
-		<texture>..\..\..\Thumbs\ClearArt\Series\#(string.trim(#Trakt.Show.TvdbId)).png</texture>
+		<texture>#fanarthandler.series.clearart.selected</texture>
         <animation effect="fade" time="250">WindowOpen</animation>
         <animation effect="fade" time="250">WindowClose</animation>
    	</control>  
@@ -26,7 +26,7 @@
    		<width>250</width>
    		<height>140</height>
     	<visible>!control.hasthumb(159357)</visible>
-		<texture>..\..\..\Thumbs\ClearLogo\Series\#(string.trim(#Trakt.Show.TvdbId)).png</texture>
+		<texture>#fanarthandler.series.clearlogo.selected</texture>
         <animation effect="fade" time="250">WindowOpen</animation>
         <animation effect="fade" time="250">WindowClose</animation>
    	</control>  

--- a/Common/Trakt.Common.Shows.xml
+++ b/Common/Trakt.Common.Shows.xml
@@ -11,7 +11,7 @@
    		<posY>150</posY>
    		<width>250</width>
    		<height>140</height>
-		<texture>#fanarthandler.series.clearart.selected</texture>
+		<texture>#fanarthandler.tvseries.clearart.selected</texture>
         <animation effect="fade" time="250">WindowOpen</animation>
         <animation effect="fade" time="250">WindowClose</animation>
    	</control>  
@@ -26,7 +26,7 @@
    		<width>250</width>
    		<height>140</height>
     	<visible>!control.hasthumb(159357)</visible>
-		<texture>#fanarthandler.series.clearlogo.selected</texture>
+		<texture>#fanarthandler.tvseries.clearlogo.selected</texture>
         <animation effect="fade" time="250">WindowOpen</animation>
         <animation effect="fade" time="250">WindowClose</animation>
    	</control>  

--- a/Common/Trakt.Popular.Movies.xml
+++ b/Common/Trakt.Popular.Movies.xml
@@ -1,0 +1,495 @@
+<?xml version="1.0" encoding="utf-8" standalone="yes"?>
+<window>
+  <id>87101</id>
+  <defaultcontrol>50</defaultcontrol>
+  <allowoverlay>no</allowoverlay>
+  <define>#Fanart.1:#Trakt.PopularMovies.Fanart.1</define>
+  <define>#Fanart.2:#Trakt.PopularMovies.Fanart.2</define>
+  <define>#header.label:#Trakt.Translation.PopularMovies.Label</define>
+  <controls>
+  <!-- #fanarthandler.movie.genres.selected -->
+    <control>
+      <description>DEFAULT BACKGROUND</description>
+      <type>image</type>
+      <id>0</id>
+      <posX>0</posX>
+      <posY>0</posY>
+      <width>1920</width>
+      <height>1080</height>
+      <texture>background.png</texture>
+      <shouldCache>true</shouldCache>
+    </control>
+    <import>Trakt.Common.Fanart.xml</import>
+    <!--            :: BACKGROUNDS ::           	 -->
+    <control>
+      <description>background listview</description>
+      <type>image</type>
+      <id>0</id>
+      <posX>0</posX>
+      <posY>0</posY>
+      <width>1920</width>
+      <height>1080</height>
+      <texture>fanart_overlay.png</texture>
+      <visible>!Control.IsVisible(51)</visible>
+      <animation effect="fade" time="250">WindowOpen</animation>
+      <animation effect="fade" time="250">WindowClose</animation>
+    </control>
+    <control>
+      <description>background listview</description>
+      <type>image</type>
+      <id>0</id>
+      <posX>10</posX>
+      <posY>252</posY>
+      <width>1903</width>
+      <height>790</height>
+      <texture>panel_list.png</texture>
+      <visible>facadeview.list + Control.IsVisible(50)</visible>
+      <animation effect="fade" time="250">WindowOpen</animation>
+      <animation effect="fade" time="250">WindowClose</animation>
+    </control>
+    <control>
+      <description>background thumbs</description>
+      <type>image</type>
+      <id>0</id>
+      <posX>10</posX>
+      <posY>252</posY>
+      <width>1903</width>
+      <height>790</height>
+      <texture>panel_tvseries_widebanner.6x2.png</texture>
+      <visible>[facadeview.smallicons | facadeview.largeicons] + Control.IsVisible(50)</visible>
+      <animation effect="fade" time="250">WindowOpen</animation>
+      <animation effect="fade" time="250">WindowClose</animation>
+    </control>
+    <control>
+      <description>filmstrip overlay</description>
+      <type>image</type>
+      <id>0</id>
+      <posX>0</posX>
+      <posY>279</posY>
+      <width>1920</width>
+      <height>801</height>
+      <texture>filmstrip_overlay.png</texture>
+      <visible>[facadeview.filmstrip | facadeview.coverflow] + Control.IsVisible(50)</visible>
+      <animation effect="fade" time="250">WindowOpen</animation>
+      <animation effect="fade" time="250">WindowClose</animation>
+    </control>
+    <control>
+      <description>filmstrip overlay</description>
+      <type>image</type>
+      <id>0</id>
+      <posX>52</posX>
+      <posY>958</posY>
+      <width>1820</width>
+      <height>84</height>
+      <texture>BasicHomeSubBG.png</texture>
+      <visible>[facadeview.filmstrip | facadeview.coverflow] + Control.IsVisible(50)</visible>
+      <animation effect="fade" time="250">WindowOpen</animation>
+      <animation effect="fade" time="250">WindowClose</animation>
+    </control>
+    <control>
+      <id>0</id>
+      <type>image</type>
+      <posX>66</posX>
+      <posY>34</posY>
+      <width>61</width>
+      <height>60</height>
+      <texture>icon_movies.png</texture>
+      <animation effect="fade" time="250">WindowOpen</animation>
+      <animation effect="fade" time="250">WindowClose</animation>
+    </control>
+    <import>common.time.xml</import>
+    
+    <!--            :: Count ::            -->
+    <control>
+      <description>Moviecount</description>
+      <type>label</type>
+      <label>#Trakt.Translation.Movies.Label: #itemcount</label>
+      <id>0</id>
+      <posX>96</posX>
+      <posY>998</posY>
+      <align>left</align>
+      <font>TitanLight12</font>
+      <textcolor>000000</textcolor>
+      <visible>[facadeview.list | facadeview.smallicons | facadeview.largeicons | facadeview.filmstrip | facadeview.coverflow] + control.isvisible(50)</visible>
+      <animation effect="fade" time="250">WindowOpen</animation>
+      <animation effect="fade" time="250">WindowClose</animation>
+    </control>
+    <!--            :: Listview Lines ::            -->
+    <control>
+      <description>List Lines</description>
+      <type>image</type>
+      <id>1</id>
+      <posX>1222</posX>
+      <posY>385</posY>
+      <width>607</width>
+      <height>506</height>
+      <texture>list_lines.png</texture>
+      <visible>facadeview.list + control.isvisible(50)</visible>
+      <animation effect="fade" time="250">WindowOpen</animation>
+      <animation effect="fade" time="250">WindowClose</animation>
+    </control>
+    <control>
+      <description>group element</description>
+      <type>group</type>
+      <animation effect="fade" time="250">WindowOpen</animation>
+      <animation effect="fade" time="250">WindowClose</animation>
+      <control>
+        <type>facadeview</type>
+        <id>50</id>
+        <control>
+          <description>Movie List</description>
+          <type>listcontrol</type>
+          <id>50</id>
+          <onleft>2</onleft>
+          <onright>2</onright>
+          <scrollOffset>1</scrollOffset>
+          <posX>1165</posX>
+          <posY>331</posY>
+          <height>700</height>
+          <width>698</width>
+          <textXOff>44</textXOff>
+          <textXOff2>650</textXOff2>
+          <textureHeight>54</textureHeight>
+          <textureFocus>listcontrol_item_selected.png</textureFocus>
+          <textureNoFocus>-</textureNoFocus>
+          <dimColor>ffffffff</dimColor>
+          <spinPosX>1828</spinPosX>
+          <spinPosY>1000</spinPosY>
+        </control>
+        <control>
+          <description>Filmstrip view</description>
+          <type>filmstrip</type>
+          <dimColor>90ffffff</dimColor>
+          <id>50</id>
+          <scrollOffset>3</scrollOffset>
+          <folderPrefix></folderPrefix>
+          <folderSuffix></folderSuffix>
+          <posX>130</posX>
+          <posY>595</posY>
+          <width>1700</width>
+          <height>340</height>
+          <onup>2</onup>
+          <ondown>2</ondown>
+          <onleft>50</onleft>
+          <onright>50</onright>
+          <thumbWidth>230</thumbWidth>
+          <thumbHeight>327</thumbHeight>
+          <thumbPosX>0</thumbPosX>
+          <thumbPosY>0</thumbPosY>
+          <itemWidth>240</itemWidth>
+          <itemHeight>327</itemHeight>
+          <textureWidth>230</textureWidth>
+          <textureHeight>327</textureHeight>
+          <textYOff>-2000</textYOff>
+          <imageFolderFocus>-</imageFolderFocus>
+          <frame>-</frame>
+          <frameFocus>-</frameFocus>
+          <background>-</background>
+          <thumbs flipY="true" diffuse="Thumb_Mask_test.png" mask="filmstrip_mask.png"></thumbs>
+          <showFrame>yes</showFrame>
+          <showFolder>no</showFolder>
+          <showBackGround>no</showBackGround>
+          <showInfoImage>no</showInfoImage>
+          <scrollbarBackground>scrollbar_bg_hor.png</scrollbarBackground>
+          <scrollbarLeft>scrollbar_left_hor.png</scrollbarLeft>
+          <scrollbarRight>scrollbar_right_hor.png</scrollbarRight>
+          <scrollbarWidth>717</scrollbarWidth>
+          <scrollbarHeight>8</scrollbarHeight>
+          <scrollbarYOff>375</scrollbarYOff>
+          <keepaspectratio>no</keepaspectratio>
+          <thumbAnimation effect="zoom" acceleration="-2" start="100,100" reversible="false" end="120,120" center="0,880" time="200">focus</thumbAnimation>
+          <thumbAnimation effect="zoom" start="120,120" reversible="false" end="100,100" center="0,880" time="100">unfocus</thumbAnimation>
+        </control>
+        <control>
+          <description>Thumbnail Panel</description>
+          <type>thumbnailpanel</type>
+          <id>50</id>
+          <posX>754</posX>
+          <posY>342</posY>
+          <width>1150</width>
+          <height>700</height>
+          <folderPrefix></folderPrefix>
+          <folderSuffix></folderSuffix>
+          <onleft>2</onleft>
+          <onright>2</onright>
+          <itemWidth>138</itemWidth>
+          <itemHeight>196</itemHeight>
+          <textureWidth>138</textureWidth>
+          <textureHeight>196</textureHeight>
+          <thumbWidth>128</thumbWidth>
+          <thumbHeight>186</thumbHeight>
+          <thumbPosX>6</thumbPosX>
+          <thumbPosY>5</thumbPosY>
+          <itemWidthBig>214</itemWidthBig>
+          <itemHeightBig>304</itemHeightBig>
+          <thumbWidthBig>204</thumbWidthBig>
+          <thumbHeightBig>294</thumbHeightBig>
+          <textureWidthBig>216</textureWidthBig>
+          <textureHeightBig>304</textureHeightBig>
+          <thumbPosXBig>6</thumbPosXBig>
+          <thumbPosYBig>5</thumbPosYBig>
+          <zoomXPixels>0</zoomXPixels>
+          <zoomYPixels>0</zoomYPixels>
+          <hideUnfocusTexture>no</hideUnfocusTexture>
+          <keepaspectratio>no</keepaspectratio>
+          <renderFocusText>no</renderFocusText>
+          <renderUnfocusText>no</renderUnfocusText>
+          <frameNoFocus>-</frameNoFocus>
+          <frameFocus>video_thumb_focus.png</frameFocus>
+          <textureMask></textureMask>
+          <shadowAngle>90</shadowAngle>
+          <shadowDistance>50</shadowDistance>
+          <thumbZoom>no</thumbZoom>
+          <spinPosX>1828</spinPosX>
+          <spinPosY>1000</spinPosY>
+          <unfocusedAlpha>100</unfocusedAlpha>
+        </control>
+        <control>
+          <description>Cover Flow view</description>
+          <type>coverflow</type>
+          <colordiffuse>90ffffff</colordiffuse>
+          <dimColor>90ffffff</dimColor>
+          <id>50</id>
+          <onup>2</onup>
+          <ondown>2</ondown>
+          <onleft>50</onleft>
+          <onright>50</onright>
+          <posX>0</posX>
+          <posY>595</posY>
+          <width>1920</width>
+          <height>340</height>
+          <selectedCard>0</selectedCard>
+          <cardWidth>238</cardWidth>
+          <cardHeight>340</cardHeight>
+          <angle>55</angle>
+          <sideShift>150</sideShift>
+          <sideGap>120</sideGap>
+          <sideDepth>110</sideDepth>
+          <offsetY>0</offsetY>
+          <selectedOffsetY>0</selectedOffsetY>
+          <speed>10</speed>
+          <showFrame>yes</showFrame>
+          <frame>-</frame>
+          <frameFocus>-</frameFocus>
+          <keepaspectratio>no</keepaspectratio>
+          <frameWidth>238</frameWidth>
+          <frameHeight>340</frameHeight>
+          <spinSpeed>8</spinSpeed>
+          <unfocusedAlpha>FF</unfocusedAlpha>
+          <folderPrefix></folderPrefix>
+          <folderSuffix></folderSuffix>
+          <font1>font13</font1>
+          <font2>font11</font2>
+          <label1>#title</label1>
+          <label2>#genre</label2>
+          <textColor>FFFFFFFF</textColor>
+          <remoteColor>FFFF0000</remoteColor>
+          <playedColor>FFA0D0FF</playedColor>
+          <downloadColor>FF00FF00</downloadColor>
+          <selectedColor>FFFFFFFF</selectedColor>
+          <shadowAngle>45</shadowAngle>
+          <shadowDistance>1</shadowDistance>
+          <shadowColor>FF000000</shadowColor>
+          <label1YOff>1430</label1YOff>
+          <label2YOff>1390</label2YOff>
+          <pageSize>5</pageSize>
+          <scrollbarBackground>scrollbar_bg_hor.png</scrollbarBackground>
+          <scrollbarLeft>scrollbar_left_hor.png</scrollbarLeft>
+          <scrollbarRight>scrollbar_right_hor.png</scrollbarRight>
+          <scrollbarWidth>717</scrollbarWidth>
+          <scrollbarHeight>8</scrollbarHeight>
+          <scrollbarYOff>375</scrollbarYOff>
+          <cards flipY="true" diffuse="Thumb_Mask_test.png" mask="filmstrip_mask.png"></cards>
+        </control>
+      </control>
+    </control>
+    <!--            :: HIDDEN MENU ::           	 -->
+    <control>
+      <id>1</id>
+      <type>image</type>
+      <posX>0</posX>
+      <posY>440</posY>
+      <width>64</width>
+      <height>199</height>
+      <texture>hiddenmenu_tab.png</texture>
+      <visible>[facadeview.list | facadeview.smallicons | facadeview.largeicons]+Control.HasFocus(50) + !string.contains(#Titan.HiddenMenu, false)</visible>
+      <animation effect="slide" start="-60,0" end="0,0" tween="quadratic" easing="in" time="250" delay="400">WindowOpen</animation>
+      <animation effect="slide" start="0,0" end="-60,0" tween="quadratic" easing="in" time="250" delay="100">WindowClose</animation>
+    </control>
+    <control>
+      <id>1</id>
+      <type>image</type>
+      <posX>858</posX>
+      <posY>0</posY>
+      <texture>hiddenmenu_tab_up.png</texture>
+      <visible>[facadeview.filmstrip | facadeview.coverflow] + Control.HasFocus(50) + !string.contains(#Titan.HiddenMenu, false)</visible>
+      <animation effect="slide" start="0,-60" end="0,0" tween="quadratic" easing="in" time="250" delay="400">WindowOpen</animation>
+      <animation effect="slide" start="0,0" end="0,-60" tween="quadratic" easing="in" time="250" delay="100">WindowClose</animation>
+    </control>
+    <control>
+      <type>actiongroup</type>
+      <description>action menu</description>
+      <defaultcontrol>3</defaultcontrol>
+      <onexit>50</onexit>
+      <dimColor>00ffffff</dimColor>
+      <buttonX>-460</buttonX>
+      <buttonY>155</buttonY>
+      <buttonwidth>499</buttonwidth>
+      <buttonheight>1080</buttonheight>
+      <control>
+        <type>image</type>
+        <id>0</id>
+        <width>1920</width>
+        <height>1080</height>
+        <texture>semi_trans_back_hidden_menu.png</texture>
+        <visible>!Control.HasFocus(50)+control.isvisible(50)</visible>
+        <animation effect="fade" time="450">visible</animation>
+        <animation effect="fade" time="400">hidden</animation>
+      </control>
+      <control>
+        <type>image</type>
+        <id>0</id>
+        <posY>0</posY>
+        <posX>0</posX>
+        <width>612</width>
+        <height>1074</height>
+        <texture>menu_bg.png</texture>
+        <visible>!Control.HasFocus(50)+control.isvisible(50)</visible>
+        <animation effect="fade" time="0">WindowClose</animation>
+        <animation effect="slide" start="-150,0" time="100">visible</animation>
+        <animation effect="fade" time="50">visible</animation>
+        <animation effect="fade" time="0">hidden</animation>
+      </control>
+      <control>
+        <description>Menu label</description>
+        <type>label</type>
+        <id>1</id>
+        <posX>116</posX>
+        <posY>100</posY>
+        <label>924</label>
+        <font>fontB16</font>
+        <textcolor>393939</textcolor>
+        <visible>!Control.HasFocus(50)+control.isvisible(50)</visible>
+        <animation effect="fade" time="0">WindowClose</animation>
+        <animation effect="slide" start="-150,0" time="100">visible</animation>
+        <animation effect="fade" time="50">visible</animation>
+        <animation effect="fade" time="0">hidden</animation>
+      </control>
+      <control>
+        <type>group</type>
+        <description>group element</description>
+        <visible>!Control.HasFocus(50)+control.isvisible(50)</visible>
+        <animation effect="fade" time="0">WindowClose</animation>
+        <animation effect="slide" start="-150,0" time="100">visible</animation>
+        <animation effect="fade" time="50">visible</animation>
+        <animation effect="fade" time="0">hidden</animation>
+        <posX>53</posX>
+        <posY>155</posY>
+        <layout>StackLayout(0, Vertical, true)</layout>
+        <control>
+          <description>Change Layout</description>
+          <type>button</type>
+          <id>2</id>
+          <textureFocus>hiddenmenu_item_selected.png</textureFocus>
+          <textureNoFocus>-</textureNoFocus>
+          <width>499</width>
+          <height>69</height>
+          <textXOff>62</textXOff>
+          <textYOff>16</textYOff>
+          <label>-</label>
+          <onright>50</onright>
+          <ondown>8</ondown>
+          <onup>8</onup>
+        </control>
+        <control>
+          <description>Sort</description>
+          <type>sortbutton</type>
+          <id>8</id>
+          <label>-</label>
+          <textureFocus>hiddenmenu_item_selected.png</textureFocus>
+          <textureNoFocus>-</textureNoFocus>
+          <width>499</width>
+          <height>69</height>
+          <textXOff>62</textXOff>
+          <textYOff>16</textYOff>
+          <offsetSortButtonX>421</offsetSortButtonX>
+          <offsetSortButtonY>27</offsetSortButtonY>
+          <onright>50</onright>
+          <onleft>50</onleft>
+          <ondown>9</ondown>
+          <onup>2</onup>
+        </control>
+        <control>
+          <description>Hide Watched</description>
+          <type>checkbutton</type>
+          <id>9</id>
+          <width>499</width>
+          <height>69</height>
+          <textureFocus>hiddenmenu_item_selected.png</textureFocus>
+          <textureNoFocus>-</textureNoFocus>
+          <textcolorNoFocus>ff393939</textcolorNoFocus>
+          <label>#Trakt.Translation.HideWatched.Label</label>
+          <onup>8</onup>
+          <ondown>10</ondown>
+          <onright>50</onright>
+          <onleft>50</onleft>
+          <textXOff>62</textXOff>
+          <textYOff>16</textYOff>
+        </control>
+        <control>
+          <description>Hide Watchlisted</description>
+          <type>checkbutton</type>
+          <id>10</id>
+          <width>499</width>
+          <height>69</height>
+          <textureFocus>hiddenmenu_item_selected.png</textureFocus>
+          <textureNoFocus>-</textureNoFocus>
+          <textcolorNoFocus>ff393939</textcolorNoFocus>
+          <label>#Trakt.Translation.HideWatchlisted.Label</label>
+          <onup>9</onup>
+          <ondown>11</ondown>
+          <onright>50</onright>
+          <onleft>50</onleft>
+          <textXOff>62</textXOff>
+          <textYOff>16</textYOff>
+        </control>
+        <control>
+          <description>Hide Collected</description>
+          <type>checkbutton</type>
+          <id>11</id>
+          <width>499</width>
+          <height>69</height>
+          <textureFocus>hiddenmenu_item_selected.png</textureFocus>
+          <textureNoFocus>-</textureNoFocus>
+          <textcolorNoFocus>ff393939</textcolorNoFocus>
+          <label>#Trakt.Translation.HideCollected.Label</label>
+          <onup>10</onup>
+          <ondown>12</ondown>
+          <onright>50</onright>
+          <onleft>50</onleft>
+          <textXOff>62</textXOff>
+          <textYOff>16</textYOff>
+        </control>
+        <control>
+          <description>Hide Rated</description>
+          <type>checkbutton</type>
+          <id>12</id>
+          <width>499</width>
+          <height>69</height>
+          <textureFocus>hiddenmenu_item_selected.png</textureFocus>
+          <textureNoFocus>-</textureNoFocus>
+          <textcolorNoFocus>ff393939</textcolorNoFocus>
+          <label>#Trakt.Translation.HideRated.Label</label>
+          <onup>11</onup>
+          <ondown>2</ondown>
+          <onright>50</onright>
+          <onleft>50</onleft>
+          <textXOff>62</textXOff>
+          <textYOff>16</textYOff>
+        </control>
+      </control>
+    </control>
+    <import>Trakt.Common.Movies.xml</import>
+    <import>common.overlay.xml</import>
+  </controls>
+</window>

--- a/Common/Trakt.Popular.Shows.xml
+++ b/Common/Trakt.Popular.Shows.xml
@@ -1,0 +1,510 @@
+<?xml version="1.0" encoding="utf-8" standalone="yes"?>
+<window>
+  <id>87102</id>
+  <defaultcontrol>50</defaultcontrol>
+  <allowoverlay>no</allowoverlay>
+  <define>#Fanart.1:#Trakt.PopularShows.Fanart.1</define>
+  <define>#Fanart.2:#Trakt.PopularShows.Fanart.2</define>
+  <define>#header.label:#Trakt.Translation.PopularShows.Label</define>
+  <controls>
+
+    <control>
+      <description>DEFAULT BACKGROUND</description>
+      <type>image</type>
+      <id>0</id>
+      <posX>0</posX>
+      <posY>0</posY>
+      <width>1920</width>
+      <height>1080</height>
+      <texture>background.png</texture>
+      <shouldCache>true</shouldCache>
+    </control>
+
+    <import>Trakt.Common.Fanart.xml</import>
+
+    <!--            :: BACKGROUNDS ::           	 -->
+
+    <control>
+      <description>background listview</description>
+      <type>image</type>
+      <id>0</id>
+      <posX>0</posX>
+      <posY>0</posY>
+      <width>1920</width>
+      <height>1080</height>
+      <texture>fanart_overlay.png</texture>
+      <visible>[facadeview.list | facadeview.smallicons | facadeview.largeicons | facadeview.filmstrip | facadeview.coverflow] + Control.IsVisible(50)</visible>
+      <animation effect="fade" time="250">WindowOpen</animation>
+      <animation effect="fade" time="250">WindowClose</animation>
+    </control>
+
+    <control>
+      <description>background listview</description>
+      <type>image</type>
+      <id>0</id>
+      <posX>10</posX>
+      <posY>252</posY>
+      <width>1903</width>
+      <height>790</height>
+      <texture>panel_list.png</texture>
+      <visible>facadeview.list + Control.IsVisible(50)</visible>
+      <animation effect="fade" time="250">WindowOpen</animation>
+      <animation effect="fade" time="250">WindowClose</animation>
+    </control>
+
+    <control>
+      <description>background thumbs</description>
+      <type>image</type>
+      <id>0</id>
+      <posX>10</posX>
+      <posY>252</posY>
+      <width>1903</width>
+      <height>790</height>
+      <texture>panel_tvseries_widebanner.6x2.png</texture>
+      <visible>[facadeview.smallicons | facadeview.largeicons] + Control.IsVisible(50)</visible>
+      <animation effect="fade" time="250">WindowOpen</animation>
+      <animation effect="fade" time="250">WindowClose</animation>
+    </control>
+
+    <control>
+      <description>filmstrip overlay</description>
+      <type>image</type>
+      <id>0</id>
+      <posX>10</posX>
+      <posY>490</posY>
+      <width>1903</width>
+      <height>552</height>
+      <texture>panel_filmstrip.png</texture>
+      <visible>[facadeview.filmstrip | facadeview.coverflow] + Control.IsVisible(50)</visible>
+      <animation effect="fade" time="250">WindowOpen</animation>
+      <animation effect="fade" time="250">WindowClose</animation>
+    </control>
+
+    <control>
+      <id>0</id>
+      <type>image</type>
+      <posX>66</posX>
+      <posY>34</posY>
+      <width>61</width>
+      <height>60</height>
+      <texture>icon_series.png</texture>
+      <animation effect="fade" time="250">WindowOpen</animation>
+      <animation effect="fade" time="250">WindowClose</animation>
+    </control>
+
+    <import>common.time.xml</import>
+
+    <!--            :: Count ::            -->
+
+    <control>
+      <description>Show Count</description>
+      <type>label</type>
+      <label>#Trakt.Translation.Series.Label: #itemcount</label>
+      <id>0</id>
+      <posX>96</posX>
+      <posY>998</posY>
+      <align>left</align>
+      <font>TitanLight12</font>
+      <textcolor>000000</textcolor>
+      <visible>[facadeview.list | facadeview.smallicons | facadeview.largeicons | facadeview.filmstrip | facadeview.coverflow] + control.isvisible(50)</visible>
+      <animation effect="fade" time="250">WindowOpen</animation>
+      <animation effect="fade" time="250">WindowClose</animation>
+    </control>
+
+    <!--            :: Listview Lines ::            -->
+
+    <control>
+      <description>List Lines</description>
+      <type>image</type>
+      <id>1</id>
+      <posX>1222</posX>
+      <posY>385</posY>
+      <width>607</width>
+      <height>506</height>
+      <texture>list_lines.png</texture>
+      <visible>facadeview.list + control.isvisible(50)</visible>
+      <animation effect="fade" time="250">WindowOpen</animation>
+      <animation effect="fade" time="250">WindowClose</animation>
+    </control>
+
+    <control>
+      <description>group element</description>
+      <type>group</type>
+      <animation effect="fade" time="250">WindowOpen</animation>
+      <animation effect="fade" time="250">WindowClose</animation>
+      <control>
+        <type>facadeview</type>
+        <id>50</id>
+        <control>
+          <description>Movie List</description>
+          <type>listcontrol</type>
+          <id>50</id>
+          <onleft>2</onleft>
+          <onright>2</onright>
+          <scrollOffset>1</scrollOffset>
+          <posX>1165</posX>
+          <posY>331</posY>
+          <height>700</height>
+          <width>698</width>
+          <textXOff>44</textXOff>
+          <textXOff2>650</textXOff2>
+          <textureHeight>54</textureHeight>
+          <textureFocus>listcontrol_item_selected.png</textureFocus>
+          <textureNoFocus>-</textureNoFocus>
+          <dimColor>ffffffff</dimColor>
+          <spinPosX>1828</spinPosX>
+          <spinPosY>1000</spinPosY>
+        </control>
+
+        <control>
+          <description>Filmstrip view</description>
+          <type>filmstrip</type>
+          <dimColor>90ffffff</dimColor>
+          <id>50</id>
+          <scrollOffset>3</scrollOffset>
+          <folderPrefix></folderPrefix>
+          <folderSuffix></folderSuffix>
+          <posX>130</posX>
+          <posY>595</posY>
+          <width>1700</width>
+          <height>340</height>
+          <onup>2</onup>
+          <ondown>2</ondown>
+          <onleft>50</onleft>
+          <onright>50</onright>
+          <thumbWidth>230</thumbWidth>
+          <thumbHeight>327</thumbHeight>
+          <thumbPosX>0</thumbPosX>
+          <thumbPosY>0</thumbPosY>
+          <itemWidth>240</itemWidth>
+          <itemHeight>327</itemHeight>
+          <textureWidth>230</textureWidth>
+          <textureHeight>327</textureHeight>
+          <textYOff>-2000</textYOff>
+          <imageFolderFocus>-</imageFolderFocus>
+          <frame>-</frame>
+          <frameFocus>-</frameFocus>
+          <background>-</background>
+          <thumbs flipY="true" diffuse="Thumb_Mask_test.png" mask="filmstrip_mask.png"></thumbs>
+          <showFrame>yes</showFrame>
+          <showFolder>no</showFolder>
+          <showBackGround>no</showBackGround>
+          <showInfoImage>no</showInfoImage>
+          <scrollbarBackground>scrollbar_bg_hor.png</scrollbarBackground>
+          <scrollbarLeft>scrollbar_left_hor.png</scrollbarLeft>
+          <scrollbarRight>scrollbar_right_hor.png</scrollbarRight>
+          <scrollbarWidth>717</scrollbarWidth>
+          <scrollbarHeight>8</scrollbarHeight>
+          <scrollbarYOff>375</scrollbarYOff>
+          <keepaspectratio>no</keepaspectratio>
+          <thumbAnimation effect="zoom" acceleration="-2" start="100,100" reversible="false" end="120,120" center="0,880" time="200">focus</thumbAnimation>
+          <thumbAnimation effect="zoom" start="120,120" reversible="false" end="100,100" center="0,880" time="100">unfocus</thumbAnimation>
+        </control>
+
+        <control>
+          <description>Thumbnail Panel</description>
+          <type>thumbnailpanel</type>
+          <id>50</id>
+          <posX>754</posX>
+          <posY>342</posY>
+          <width>1150</width>
+          <height>700</height>
+          <folderPrefix></folderPrefix>
+          <folderSuffix></folderSuffix>
+          <onleft>2</onleft>
+          <onright>2</onright>
+          <itemWidth>138</itemWidth>
+          <itemHeight>196</itemHeight>
+          <textureWidth>138</textureWidth>
+          <textureHeight>196</textureHeight>
+          <thumbWidth>128</thumbWidth>
+          <thumbHeight>186</thumbHeight>
+          <thumbPosX>6</thumbPosX>
+          <thumbPosY>5</thumbPosY>
+          <itemWidthBig>214</itemWidthBig>
+          <itemHeightBig>304</itemHeightBig>
+          <thumbWidthBig>204</thumbWidthBig>
+          <thumbHeightBig>294</thumbHeightBig>
+          <textureWidthBig>216</textureWidthBig>
+          <textureHeightBig>304</textureHeightBig>
+          <thumbPosXBig>6</thumbPosXBig>
+          <thumbPosYBig>5</thumbPosYBig>
+          <zoomXPixels>0</zoomXPixels>
+          <zoomYPixels>0</zoomYPixels>
+          <hideUnfocusTexture>no</hideUnfocusTexture>
+          <keepaspectratio>no</keepaspectratio>
+          <renderFocusText>no</renderFocusText>
+          <renderUnfocusText>no</renderUnfocusText>
+          <frameNoFocus>-</frameNoFocus>
+          <frameFocus>video_thumb_focus.png</frameFocus>
+          <textureMask></textureMask>
+          <shadowAngle>90</shadowAngle>
+          <shadowDistance>50</shadowDistance>
+          <thumbZoom>no</thumbZoom>
+          <spinPosX>1828</spinPosX>
+          <spinPosY>1000</spinPosY>
+          <unfocusedAlpha>100</unfocusedAlpha>
+        </control>
+
+        <control>
+          <description>Cover Flow view</description>
+          <type>coverflow</type>
+          <colordiffuse>90ffffff</colordiffuse>
+          <dimColor>90ffffff</dimColor>
+          <id>50</id>
+          <onup>2</onup>
+          <ondown>2</ondown>
+          <onleft>50</onleft>
+          <onright>50</onright>
+          <posX>0</posX>
+          <posY>595</posY>
+          <width>1920</width>
+          <height>340</height>
+          <selectedCard>0</selectedCard>
+          <cardWidth>238</cardWidth>
+          <cardHeight>340</cardHeight>
+          <angle>55</angle>
+          <sideShift>150</sideShift>
+          <sideGap>120</sideGap>
+          <sideDepth>110</sideDepth>
+          <offsetY>0</offsetY>
+          <selectedOffsetY>0</selectedOffsetY>
+          <speed>10</speed>
+          <showFrame>yes</showFrame>
+          <frame>-</frame>
+          <frameFocus>-</frameFocus>
+          <keepaspectratio>no</keepaspectratio>
+          <frameWidth>238</frameWidth>
+          <frameHeight>340</frameHeight>
+          <spinSpeed>8</spinSpeed>
+          <unfocusedAlpha>FF</unfocusedAlpha>
+          <folderPrefix></folderPrefix>
+          <folderSuffix></folderSuffix>
+          <font1>font13</font1>
+          <font2>font11</font2>
+          <label1>#title</label1>
+          <label2>#genre</label2>
+          <textColor>FFFFFFFF</textColor>
+          <remoteColor>FFFF0000</remoteColor>
+          <playedColor>FFA0D0FF</playedColor>
+          <downloadColor>FF00FF00</downloadColor>
+          <selectedColor>FFFFFFFF</selectedColor>
+          <shadowAngle>45</shadowAngle>
+          <shadowDistance>1</shadowDistance>
+          <shadowColor>FF000000</shadowColor>
+          <label1YOff>1430</label1YOff>
+          <label2YOff>1390</label2YOff>
+          <pageSize>5</pageSize>
+          <scrollbarBackground>scrollbar_bg_hor.png</scrollbarBackground>
+          <scrollbarLeft>scrollbar_left_hor.png</scrollbarLeft>
+          <scrollbarRight>scrollbar_right_hor.png</scrollbarRight>
+          <scrollbarWidth>717</scrollbarWidth>
+          <scrollbarHeight>8</scrollbarHeight>
+          <scrollbarYOff>375</scrollbarYOff>
+          <cards flipY="true" diffuse="Thumb_Mask_test.png" mask="filmstrip_mask.png"></cards>
+        </control>
+      </control>
+    </control>
+
+    <!--            :: HIDDEN MENU ::           	 -->
+
+    <control>
+      <id>1</id>
+      <type>image</type>
+      <posX>0</posX>
+      <posY>440</posY>
+      <width>64</width>
+      <height>199</height>
+      <texture>hiddenmenu_tab.png</texture>
+      <visible>[facadeview.list | facadeview.smallicons | facadeview.largeicons]+Control.HasFocus(50) + !string.contains(#Titan.HiddenMenu, false)</visible>
+      <animation effect="slide" start="-60,0" end="0,0" tween="quadratic" easing="in" time="250" delay="400">WindowOpen</animation>
+      <animation effect="slide" start="0,0" end="-60,0" tween="quadratic" easing="in" time="250" delay="100">WindowClose</animation>
+    </control>
+
+    <control>
+      <id>1</id>
+      <type>image</type>
+      <posX>858</posX>
+      <posY>0</posY>
+      <texture>hiddenmenu_tab_up.png</texture>
+      <visible>[facadeview.filmstrip | facadeview.coverflow] + Control.HasFocus(50) + !string.contains(#Titan.HiddenMenu, false)</visible>
+      <animation effect="slide" start="0,-60" end="0,0" tween="quadratic" easing="in" time="250" delay="400">WindowOpen</animation>
+      <animation effect="slide" start="0,0" end="0,-60" tween="quadratic" easing="in" time="250" delay="100">WindowClose</animation>
+    </control>
+
+    <control>
+      <type>actiongroup</type>
+      <description>action menu</description>
+      <defaultcontrol>3</defaultcontrol>
+      <onexit>50</onexit>
+      <dimColor>00ffffff</dimColor>
+      <buttonX>-460</buttonX>
+      <buttonY>155</buttonY>
+      <buttonwidth>499</buttonwidth>
+      <buttonheight>1080</buttonheight>
+
+      <control>
+        <type>image</type>
+        <id>0</id>
+        <width>1920</width>
+        <height>1080</height>
+        <texture>semi_trans_back_hidden_menu.png</texture>
+        <visible>!Control.HasFocus(50)+control.isvisible(50)</visible>
+        <animation effect="fade" time="450">visible</animation>
+        <animation effect="fade" time="400">hidden</animation>
+      </control>
+
+      <control>
+        <type>image</type>
+        <id>0</id>
+        <posY>0</posY>
+        <posX>0</posX>
+        <width>612</width>
+        <height>1074</height>
+        <texture>menu_bg.png</texture>
+        <visible>!Control.HasFocus(50)+control.isvisible(50)</visible>
+        <animation effect="fade" time="0">WindowClose</animation>
+        <animation effect="slide" start="-150,0" time="100">visible</animation>
+        <animation effect="fade" time="50">visible</animation>
+        <animation effect="fade" time="0">hidden</animation>
+      </control>
+      <control>
+        <description>Menu label</description>
+        <type>label</type>
+        <id>1</id>
+        <posX>116</posX>
+        <posY>100</posY>
+        <label>924</label>
+        <font>fontB16</font>
+        <textcolor>393939</textcolor>
+        <visible>!Control.HasFocus(50)+control.isvisible(50)</visible>
+        <animation effect="fade" time="0">WindowClose</animation>
+        <animation effect="slide" start="-150,0" time="100">visible</animation>
+        <animation effect="fade" time="50">visible</animation>
+        <animation effect="fade" time="0">hidden</animation>
+      </control>
+      <control>
+        <type>group</type>
+        <description>group element</description>
+        <visible>!Control.HasFocus(50)+control.isvisible(50)</visible>
+        <animation effect="fade" time="0">WindowClose</animation>
+        <animation effect="slide" start="-150,0" time="100">visible</animation>
+        <animation effect="fade" time="50">visible</animation>
+        <animation effect="fade" time="0">hidden</animation>
+        <posX>53</posX>
+        <posY>155</posY>
+        <layout>StackLayout(0, Vertical, true)</layout>
+
+        <control>
+          <description>Change Layout</description>
+          <type>button</type>
+          <id>2</id>
+          <textureFocus>hiddenmenu_item_selected.png</textureFocus>
+          <textureNoFocus>-</textureNoFocus>
+          <width>499</width>
+          <height>69</height>
+          <textXOff>62</textXOff>
+          <textYOff>16</textYOff>
+          <label>-</label>
+          <onright>50</onright>
+          <ondown>8</ondown>
+          <onup>8</onup>
+        </control>
+
+        <control>
+          <description>Sort</description>
+          <type>sortbutton</type>
+          <id>8</id>
+          <label>-</label>
+          <textureFocus>hiddenmenu_item_selected.png</textureFocus>
+          <textureNoFocus>-</textureNoFocus>
+          <width>499</width>
+          <height>69</height>
+          <textXOff>62</textXOff>
+          <textYOff>16</textYOff>
+          <offsetSortButtonX>421</offsetSortButtonX>
+          <offsetSortButtonY>27</offsetSortButtonY>
+          <onright>50</onright>
+          <onleft>50</onleft>
+          <ondown>9</ondown>
+          <onup>2</onup>
+        </control>
+
+        <control>
+          <description>Hide Watched</description>
+          <type>checkbutton</type>
+          <id>9</id>
+          <width>499</width>
+          <height>69</height>
+          <textureFocus>hiddenmenu_item_selected.png</textureFocus>
+          <textureNoFocus>-</textureNoFocus>
+          <label>#Trakt.Translation.HideWatched.Label</label>
+          <textcolorNoFocus>ff393939</textcolorNoFocus>
+          <onup>8</onup>
+          <ondown>10</ondown>
+          <onright>50</onright>
+          <onleft>50</onleft>
+          <textXOff>62</textXOff>
+          <textYOff>16</textYOff>
+        </control>
+
+        <control>
+          <description>Hide Watchlisted</description>
+          <type>checkbutton</type>
+          <id>10</id>
+          <width>499</width>
+          <height>69</height>
+          <textureFocus>hiddenmenu_item_selected.png</textureFocus>
+          <textureNoFocus>-</textureNoFocus>
+          <label>#Trakt.Translation.HideWatchlisted.Label</label>
+          <textcolorNoFocus>ff393939</textcolorNoFocus>
+          <onup>9</onup>
+          <ondown>11</ondown>
+          <onright>50</onright>
+          <onleft>50</onleft>
+          <textXOff>62</textXOff>
+          <textYOff>16</textYOff>
+        </control>
+
+        <control>
+          <description>Hide Collected</description>
+          <type>checkbutton</type>
+          <id>11</id>
+          <width>499</width>
+          <height>69</height>
+          <textureFocus>hiddenmenu_item_selected.png</textureFocus>
+          <textureNoFocus>-</textureNoFocus>
+          <label>#Trakt.Translation.HideCollected.Label</label>
+          <textcolorNoFocus>ff393939</textcolorNoFocus>
+          <onup>10</onup>
+          <ondown>12</ondown>
+          <onright>50</onright>
+          <onleft>50</onleft>
+          <textXOff>62</textXOff>
+          <textYOff>16</textYOff>
+        </control>
+
+        <control>
+          <description>Hide Rated</description>
+          <type>checkbutton</type>
+          <id>12</id>
+          <width>499</width>
+          <height>69</height>
+          <textureFocus>hiddenmenu_item_selected.png</textureFocus>
+          <textureNoFocus>-</textureNoFocus>
+          <textcolorNoFocus>ff393939</textcolorNoFocus>
+          <label>#Trakt.Translation.HideRated.Label</label>
+          <onup>11</onup>
+          <ondown>2</ondown>
+          <onright>50</onright>
+          <onleft>50</onleft>
+          <textXOff>62</textXOff>
+          <textYOff>16</textYOff>
+        </control>
+
+      </control>
+    </control>
+    <import>Trakt.Common.Shows.xml</import>
+    <import>common.overlay.xml</import>
+  </controls>
+</window>

--- a/Common/Trakt.Recommendations.Movies.xml
+++ b/Common/Trakt.Recommendations.Movies.xml
@@ -1,0 +1,591 @@
+<?xml version="1.0" encoding="utf-8" standalone="yes"?>
+<window>
+  <id>87263</id>
+  <defaultcontrol>50</defaultcontrol>
+  <allowoverlay>no</allowoverlay>
+  <define>#Fanart.1:#Trakt.RecommendedMovies.Fanart.1</define>
+  <define>#Fanart.2:#Trakt.RecommendedMovies.Fanart.2</define>
+  <define>#header.label:#Trakt.Translation.RecommendedMovies.Label</define>
+  <controls>
+  <!-- #fanarthandler.movie.genres.selected -->
+    <control>
+      <description>DEFAULT BACKGROUND</description>
+      <type>image</type>
+      <id>0</id>
+      <posX>0</posX>
+      <posY>0</posY>
+      <width>1920</width>
+      <height>1080</height>
+      <texture>background.png</texture>
+      <shouldCache>true</shouldCache>
+    </control>
+
+    <import>Trakt.Common.Fanart.xml</import>
+
+    <!--            :: BACKGROUNDS ::           	 -->
+    <control>
+      <description>background listview</description>
+      <type>image</type>
+      <id>0</id>
+      <posX>0</posX>
+      <posY>0</posY>
+      <width>1920</width>
+      <height>1080</height>
+      <texture>fanart_overlay.png</texture>
+      <visible>!Control.IsVisible(51)</visible>
+      <animation effect="fade" time="250">WindowOpen</animation>
+      <animation effect="fade" time="250">WindowClose</animation>
+    </control>
+
+    <control>
+      <description>background listview</description>
+      <type>image</type>
+      <id>0</id>
+      <posX>10</posX>
+      <posY>252</posY>
+      <width>1903</width>
+      <height>790</height>
+      <texture>panel_list.png</texture>
+      <visible>facadeview.list + Control.IsVisible(50)</visible>
+      <animation effect="fade" time="250">WindowOpen</animation>
+      <animation effect="fade" time="250">WindowClose</animation>
+    </control>
+
+    <control>
+      <description>background thumbs</description>
+      <type>image</type>
+      <id>0</id>
+      <posX>10</posX>
+      <posY>252</posY>
+      <width>1903</width>
+      <height>790</height>
+      <texture>panel_tvseries_widebanner.6x2.png</texture>
+      <visible>[facadeview.smallicons | facadeview.largeicons] + Control.IsVisible(50)</visible>
+      <animation effect="fade" time="250">WindowOpen</animation>
+      <animation effect="fade" time="250">WindowClose</animation>
+    </control>
+
+    <control>
+      <description>filmstrip overlay</description>
+      <type>image</type>
+      <id>0</id>
+      <posX>0</posX>
+      <posY>279</posY>
+      <width>1920</width>
+      <height>801</height>
+      <texture>filmstrip_overlay.png</texture>
+      <visible>[facadeview.filmstrip | facadeview.coverflow] + Control.IsVisible(50)</visible>
+      <animation effect="fade" time="250">WindowOpen</animation>
+      <animation effect="fade" time="250">WindowClose</animation>
+    </control>
+
+    <control>
+      <description>filmstrip overlay</description>
+      <type>image</type>
+      <id>0</id>
+      <posX>52</posX>
+      <posY>958</posY>
+      <width>1820</width>
+      <height>84</height>
+      <texture>BasicHomeSubBG.png</texture>
+      <visible>[facadeview.filmstrip | facadeview.coverflow] + Control.IsVisible(50)</visible>
+      <animation effect="fade" time="250">WindowOpen</animation>
+      <animation effect="fade" time="250">WindowClose</animation>
+    </control>
+
+    <control>
+      <id>0</id>
+      <type>image</type>
+      <posX>66</posX>
+      <posY>34</posY>
+      <width>61</width>
+      <height>60</height>
+      <texture>icon_movies.png</texture>
+      <animation effect="fade" time="250">WindowOpen</animation>
+      <animation effect="fade" time="250">WindowClose</animation>
+    </control>
+    <import>common.time.xml</import>
+    <control>
+      <description>Current View</description>
+      <type>label</type>
+      <label>Trakt</label>
+      <id>0</id>
+      <posX>144</posX>
+      <posY>94</posY>
+      <align>left</align>
+      <textcolor>FFFFFFFF</textcolor>
+      <font>TitanLight12</font>
+      <animation effect="fade" time="250">WindowOpen</animation>
+      <animation effect="fade" time="250">WindowClose</animation>
+    </control>
+
+    <!--            :: Count ::            -->
+
+    <control>
+      <description>Movie Count</description>
+      <type>label</type>
+      <label>#Trakt.Translation.Movies.Label: #itemcount</label>
+      <id>0</id>
+      <posX>96</posX>
+      <posY>998</posY>
+      <align>left</align>
+      <font>TitanLight12</font>
+      <textcolor>000000</textcolor>
+      <visible>[facadeview.list | facadeview.smallicons | facadeview.largeicons | facadeview.filmstrip | facadeview.coverflow] + control.isvisible(50)</visible>
+      <animation effect="fade" time="250">WindowOpen</animation>
+      <animation effect="fade" time="250">WindowClose</animation>
+    </control>
+
+    <!--            :: Listview Lines ::            -->
+
+    <control>
+      <description>List Lines</description>
+      <type>image</type>
+      <id>1</id>
+      <posX>1222</posX>
+      <posY>385</posY>
+      <width>607</width>
+      <height>506</height>
+      <texture>list_lines.png</texture>
+      <visible>facadeview.list + control.isvisible(50)</visible>
+      <animation effect="fade" time="250">WindowOpen</animation>
+      <animation effect="fade" time="250">WindowClose</animation>
+    </control>
+
+    <control>
+      <description>group element</description>
+      <type>group</type>
+      <animation effect="fade" time="250">WindowOpen</animation>
+      <animation effect="fade" time="250">WindowClose</animation>
+      <control>
+        <type>facadeview</type>
+        <id>50</id>
+        <control>
+          <description>Movie List</description>
+          <type>listcontrol</type>
+          <id>50</id>
+          <onleft>2</onleft>
+          <onright>2</onright>
+          <scrollOffset>1</scrollOffset>
+          <posX>1165</posX>
+          <posY>331</posY>
+          <height>700</height>
+          <width>698</width>
+          <textXOff>44</textXOff>
+          <textXOff2>650</textXOff2>
+          <textureHeight>54</textureHeight>
+          <textureFocus>listcontrol_item_selected.png</textureFocus>
+          <textureNoFocus>-</textureNoFocus>
+          <dimColor>ffffffff</dimColor>
+          <spinPosX>1828</spinPosX>
+          <spinPosY>1000</spinPosY>
+        </control>
+
+        <control>
+          <description>Filmstrip view</description>
+          <type>filmstrip</type>
+          <dimColor>90ffffff</dimColor>
+          <id>50</id>
+          <scrollOffset>3</scrollOffset>
+          <folderPrefix></folderPrefix>
+          <folderSuffix></folderSuffix>
+          <posX>130</posX>
+          <posY>595</posY>
+          <width>1700</width>
+          <height>340</height>
+          <onup>2</onup>
+          <ondown>2</ondown>
+          <onleft>50</onleft>
+          <onright>50</onright>
+          <thumbWidth>230</thumbWidth>
+          <thumbHeight>327</thumbHeight>
+          <thumbPosX>0</thumbPosX>
+          <thumbPosY>0</thumbPosY>
+          <itemWidth>240</itemWidth>
+          <itemHeight>327</itemHeight>
+          <textureWidth>230</textureWidth>
+          <textureHeight>327</textureHeight>
+          <textYOff>-2000</textYOff>
+          <imageFolderFocus>-</imageFolderFocus>
+          <frame>-</frame>
+          <frameFocus>-</frameFocus>
+          <background>-</background>
+          <thumbs flipY="true" diffuse="Thumb_Mask_test.png" mask="filmstrip_mask.png"></thumbs>
+          <showFrame>yes</showFrame>
+          <showFolder>no</showFolder>
+          <showBackGround>no</showBackGround>
+          <showInfoImage>no</showInfoImage>
+          <scrollbarBackground>scrollbar_bg_hor.png</scrollbarBackground>
+          <scrollbarLeft>scrollbar_left_hor.png</scrollbarLeft>
+          <scrollbarRight>scrollbar_right_hor.png</scrollbarRight>
+          <scrollbarWidth>717</scrollbarWidth>
+          <scrollbarHeight>8</scrollbarHeight>
+          <scrollbarYOff>375</scrollbarYOff>
+          <keepaspectratio>no</keepaspectratio>
+          <thumbAnimation effect="zoom" acceleration="-2" start="100,100" reversible="false" end="120,120" center="0,880" time="200">focus</thumbAnimation>
+          <thumbAnimation effect="zoom" start="120,120" reversible="false" end="100,100" center="0,880" time="100">unfocus</thumbAnimation>
+        </control>
+
+        <control>
+          <description>Thumbnail Panel</description>
+          <type>thumbnailpanel</type>
+          <id>50</id>
+          <posX>754</posX>
+          <posY>342</posY>
+          <width>1150</width>
+          <height>700</height>
+          <folderPrefix></folderPrefix>
+          <folderSuffix></folderSuffix>
+          <onleft>2</onleft>
+          <onright>2</onright>
+          <itemWidth>138</itemWidth>
+          <itemHeight>196</itemHeight>
+          <textureWidth>138</textureWidth>
+          <textureHeight>196</textureHeight>
+          <thumbWidth>128</thumbWidth>
+          <thumbHeight>186</thumbHeight>
+          <thumbPosX>6</thumbPosX>
+          <thumbPosY>5</thumbPosY>
+          <itemWidthBig>214</itemWidthBig>
+          <itemHeightBig>304</itemHeightBig>
+          <thumbWidthBig>204</thumbWidthBig>
+          <thumbHeightBig>294</thumbHeightBig>
+          <textureWidthBig>216</textureWidthBig>
+          <textureHeightBig>304</textureHeightBig>
+          <thumbPosXBig>6</thumbPosXBig>
+          <thumbPosYBig>5</thumbPosYBig>
+          <zoomXPixels>0</zoomXPixels>
+          <zoomYPixels>0</zoomYPixels>
+          <hideUnfocusTexture>no</hideUnfocusTexture>
+          <keepaspectratio>no</keepaspectratio>
+          <renderFocusText>no</renderFocusText>
+          <renderUnfocusText>no</renderUnfocusText>
+          <frameNoFocus>-</frameNoFocus>
+          <frameFocus>video_thumb_focus.png</frameFocus>
+          <textureMask></textureMask>
+          <shadowAngle>90</shadowAngle>
+          <shadowDistance>50</shadowDistance>
+          <thumbZoom>no</thumbZoom>
+          <spinPosX>1828</spinPosX>
+          <spinPosY>1000</spinPosY>
+          <unfocusedAlpha>100</unfocusedAlpha>
+        </control>
+
+        <control>
+          <description>Cover Flow view</description>
+          <type>coverflow</type>
+          <colordiffuse>90ffffff</colordiffuse>
+          <dimColor>90ffffff</dimColor>
+          <id>50</id>
+          <onup>2</onup>
+          <ondown>2</ondown>
+          <onleft>50</onleft>
+          <onright>50</onright>
+          <posX>0</posX>
+          <posY>595</posY>
+          <width>1920</width>
+          <height>340</height>
+          <selectedCard>0</selectedCard>
+          <cardWidth>238</cardWidth>
+          <cardHeight>340</cardHeight>
+          <angle>55</angle>
+          <sideShift>150</sideShift>
+          <sideGap>120</sideGap>
+          <sideDepth>110</sideDepth>
+          <offsetY>0</offsetY>
+          <selectedOffsetY>0</selectedOffsetY>
+          <speed>10</speed>
+          <showFrame>yes</showFrame>
+          <frame>-</frame>
+          <frameFocus>-</frameFocus>
+          <keepaspectratio>no</keepaspectratio>
+          <frameWidth>238</frameWidth>
+          <frameHeight>340</frameHeight>
+          <spinSpeed>8</spinSpeed>
+          <unfocusedAlpha>FF</unfocusedAlpha>
+          <folderPrefix></folderPrefix>
+          <folderSuffix></folderSuffix>
+          <font1>font13</font1>
+          <font2>font11</font2>
+          <label1>#title</label1>
+          <label2>#genre</label2>
+          <textColor>FFFFFFFF</textColor>
+          <remoteColor>FFFF0000</remoteColor>
+          <playedColor>FFA0D0FF</playedColor>
+          <downloadColor>FF00FF00</downloadColor>
+          <selectedColor>FFFFFFFF</selectedColor>
+          <shadowAngle>45</shadowAngle>
+          <shadowDistance>1</shadowDistance>
+          <shadowColor>FF000000</shadowColor>
+          <label1YOff>1430</label1YOff>
+          <label2YOff>1390</label2YOff>
+          <pageSize>5</pageSize>
+          <scrollbarBackground>scrollbar_bg_hor.png</scrollbarBackground>
+          <scrollbarLeft>scrollbar_left_hor.png</scrollbarLeft>
+          <scrollbarRight>scrollbar_right_hor.png</scrollbarRight>
+          <scrollbarWidth>717</scrollbarWidth>
+          <scrollbarHeight>8</scrollbarHeight>
+          <scrollbarYOff>375</scrollbarYOff>
+          <cards flipY="true" diffuse="Thumb_Mask_test.png" mask="filmstrip_mask.png"></cards>
+        </control>
+      </control>
+    </control>
+
+    <!--            :: HIDDEN MENU ::           	 -->
+
+    <control>
+      <id>1</id>
+      <type>image</type>
+      <posX>0</posX>
+      <posY>440</posY>
+      <width>64</width>
+      <height>199</height>
+      <texture>hiddenmenu_tab.png</texture>
+      <visible>[facadeview.list | facadeview.smallicons | facadeview.largeicons]+Control.HasFocus(50) + !string.contains(#Titan.HiddenMenu, false)</visible>
+      <animation effect="slide" start="-60,0" end="0,0" tween="quadratic" easing="in" time="250" delay="400">WindowOpen</animation>
+      <animation effect="slide" start="0,0" end="-60,0" tween="quadratic" easing="in" time="250" delay="100">WindowClose</animation>
+    </control>
+
+    <control>
+      <id>1</id>
+      <type>image</type>
+      <posX>858</posX>
+      <posY>0</posY>
+      <texture>hiddenmenu_tab_up.png</texture>
+      <visible>[facadeview.filmstrip | facadeview.coverflow] + Control.HasFocus(50) + !string.contains(#Titan.HiddenMenu, false)</visible>
+      <animation effect="slide" start="0,-60" end="0,0" tween="quadratic" easing="in" time="250" delay="400">WindowOpen</animation>
+      <animation effect="slide" start="0,0" end="0,-60" tween="quadratic" easing="in" time="250" delay="100">WindowClose</animation>
+    </control>
+
+    <control>
+      <type>actiongroup</type>
+      <description>action menu</description>
+      <defaultcontrol>3</defaultcontrol>
+      <onexit>50</onexit>
+      <dimColor>00ffffff</dimColor>
+      <buttonX>-460</buttonX>
+      <buttonY>155</buttonY>
+      <buttonwidth>499</buttonwidth>
+      <buttonheight>1080</buttonheight>
+
+      <control>
+        <type>image</type>
+        <id>0</id>
+        <width>1920</width>
+        <height>1080</height>
+        <texture>semi_trans_back_hidden_menu.png</texture>
+        <visible>!Control.HasFocus(50)+control.isvisible(50)</visible>
+        <animation effect="fade" time="450">visible</animation>
+        <animation effect="fade" time="400">hidden</animation>
+      </control>
+
+      <control>
+        <type>image</type>
+        <id>0</id>
+        <posY>0</posY>
+        <posX>0</posX>
+        <width>612</width>
+        <height>1074</height>
+        <texture>menu_bg.png</texture>
+        <visible>!Control.HasFocus(50)+control.isvisible(50)</visible>
+        <animation effect="fade" time="0">WindowClose</animation>
+        <animation effect="slide" start="-150,0" time="100">visible</animation>
+        <animation effect="fade" time="50">visible</animation>
+        <animation effect="fade" time="0">hidden</animation>
+      </control>
+      <control>
+        <type>image</type>
+        <id>0</id>
+        <posY>375</posY>
+        <posX>116</posX>
+        <width>369</width>
+        <height>1</height>
+        <texture>hiddenmenu_separator.png</texture>
+        <visible>!Control.HasFocus(50)+control.isvisible(50)</visible>
+        <animation effect="fade" time="0">WindowClose</animation>
+        <animation effect="slide" start="-150,0" time="100">visible</animation>
+        <animation effect="fade" time="50">visible</animation>
+        <animation effect="fade" time="0">hidden</animation>
+      </control>
+      <control>
+        <description>Menu label</description>
+        <type>label</type>
+        <id>1</id>
+        <posX>116</posX>
+        <posY>100</posY>
+        <label>924</label>
+        <font>fontB16</font>
+        <textcolor>393939</textcolor>
+        <visible>!Control.HasFocus(50)+control.isvisible(50)</visible>
+        <animation effect="fade" time="0">WindowClose</animation>
+        <animation effect="slide" start="-150,0" time="100">visible</animation>
+        <animation effect="fade" time="50">visible</animation>
+        <animation effect="fade" time="0">hidden</animation>
+      </control>
+      <control>
+        <description>Settings label</description>
+        <type>label</type>
+        <id>1</id>
+        <posX>116</posX>
+        <posY>385</posY>
+        <label>496</label>
+        <font>fontB12</font>
+        <textcolor>393939</textcolor>
+        <visible>!Control.HasFocus(50)+control.isvisible(50)</visible>
+        <animation effect="fade" time="0">WindowClose</animation>
+        <animation effect="slide" start="-150,0" time="100">visible</animation>
+        <animation effect="fade" time="50">visible</animation>
+        <animation effect="fade" time="0">hidden</animation>
+      </control>
+      <control>
+        <type>group</type>
+        <description>group element</description>
+        <visible>!Control.HasFocus(50)+control.isvisible(50)</visible>
+        <animation effect="fade" time="0">WindowClose</animation>
+        <animation effect="slide" start="-150,0" time="100">visible</animation>
+        <animation effect="fade" time="50">visible</animation>
+        <animation effect="fade" time="0">hidden</animation>
+        <posX>53</posX>
+        <posY>155</posY>
+        <layout>StackLayout(0, Vertical, true)</layout>
+
+        <control>
+          <description>Change Layout</description>
+          <type>button</type>
+          <id>2</id>
+          <textureFocus>hiddenmenu_item_selected.png</textureFocus>
+          <textureNoFocus>-</textureNoFocus>
+          <width>499</width>
+          <height>69</height>
+          <textXOff>62</textXOff>
+          <textYOff>16</textYOff>
+          <label>-</label>
+          <onright>50</onright>
+          <ondown>8</ondown>
+          <onup>7</onup>
+        </control>
+
+        <control>
+          <description>Sort</description>
+          <type>sortbutton</type>
+          <id>8</id>
+          <label>-</label>
+          <textureFocus>hiddenmenu_item_selected.png</textureFocus>
+          <textureNoFocus>-</textureNoFocus>
+          <width>499</width>
+          <height>69</height>
+          <textXOff>62</textXOff>
+          <textYOff>16</textYOff>
+          <offsetSortButtonX>421</offsetSortButtonX>
+          <offsetSortButtonY>27</offsetSortButtonY>
+          <onright>50</onright>
+          <onleft>50</onleft>
+          <ondown>3</ondown>
+          <onup>2</onup>
+        </control>
+
+        <control>
+          <description>Genres</description>
+          <type>button</type>
+          <id>3</id>
+          <label>-</label>
+          <onleft>50</onleft>
+          <onright>50</onright>
+          <textureFocus>hiddenmenu_item_selected.png</textureFocus>
+          <textureNoFocus>-</textureNoFocus>
+          <width>499</width>
+          <height>69</height>
+          <textXOff>62</textXOff>
+          <textYOff>16</textYOff>
+          <ondown>4</ondown>
+          <onup>8</onup>
+        </control>
+
+        <control>
+          <description>Empty button</description>
+          <type>button</type>
+          <id>0</id>
+          <textureFocus>-</textureFocus>
+          <textureNoFocus>-</textureNoFocus>
+          <width>499</width>
+          <height>69</height>
+          <label>-</label>
+          <visible>true</visible>
+        </control>
+
+        <control>
+          <description>Toggle Hide Collected</description>
+          <type>checkbutton</type>
+          <id>4</id>
+          <label>#Trakt.Translation.HideCollected.Label</label>
+          <textureFocus>hiddenmenu_item_selected.png</textureFocus>
+          <textureNoFocus>-</textureNoFocus>
+          <textcolor>FFFFFFFF</textcolor>
+          <textcolorNoFocus>ff393939</textcolorNoFocus>
+          <width>499</width>
+          <height>69</height>
+          <textXOff>62</textXOff>
+          <textYOff>16</textYOff>
+          <markXOff>38</markXOff>
+          <onleft>50</onleft>
+          <onright>50</onright>
+          <ondown>5</ondown>
+          <onup>3</onup>
+        </control>
+        <control>
+          <description>Toggle Hide Watchlisted</description>
+          <type>checkbutton</type>
+          <id>5</id>
+          <label>#Trakt.Translation.HideWatchlisted.Label</label>
+          <textureFocus>hiddenmenu_item_selected.png</textureFocus>
+          <textureNoFocus>-</textureNoFocus>
+          <textcolor>FFFFFFFF</textcolor>
+          <textcolorNoFocus>ff393939</textcolorNoFocus>
+          <width>499</width>
+          <height>69</height>
+          <textXOff>62</textXOff>
+          <textYOff>16</textYOff>
+          <markXOff>38</markXOff>
+          <onleft>50</onleft>
+          <onright>50</onright>
+          <ondown>6</ondown>
+          <onup>4</onup>
+        </control>
+        <control>
+          <description>Start Year</description>
+          <type>button</type>
+          <id>6</id>
+          <label>-</label>
+          <onleft>50</onleft>
+          <onright>50</onright>
+          <textureFocus>hiddenmenu_item_selected.png</textureFocus>
+          <textureNoFocus>-</textureNoFocus>
+          <width>499</width>
+          <height>69</height>
+          <textXOff>62</textXOff>
+          <textYOff>16</textYOff>
+          <ondown>7</ondown>
+          <onup>5</onup>
+        </control>
+        <control>
+          <description>End Year</description>
+          <type>button</type>
+          <id>7</id>
+          <label>-</label>
+          <onleft>50</onleft>
+          <onright>50</onright>
+          <textureFocus>hiddenmenu_item_selected.png</textureFocus>
+          <textureNoFocus>-</textureNoFocus>
+          <width>499</width>
+          <height>69</height>
+          <textXOff>62</textXOff>
+          <textYOff>16</textYOff>
+          <ondown>2</ondown>
+          <onup>6</onup>
+        </control>
+      </control>
+    </control>
+    <import>Trakt.Common.Movies.xml</import>
+    <import>common.overlay.xml</import>
+  </controls>
+</window>

--- a/Common/Trakt.Recommendations.Shows.xml
+++ b/Common/Trakt.Recommendations.Shows.xml
@@ -1,0 +1,593 @@
+<?xml version="1.0" encoding="utf-8" standalone="yes"?>
+<window>
+  <id>87262</id>
+  <defaultcontrol>50</defaultcontrol>
+  <allowoverlay>no</allowoverlay>
+  <define>#Fanart.1:#Trakt.RecommendedShows.Fanart.1</define>
+  <define>#Fanart.2:#Trakt.RecommendedShows.Fanart.2</define>
+  <define>#header.label:#Trakt.Translation.RecommendedShows.Label</define>
+  <controls>
+
+    <control>
+      <description>DEFAULT BACKGROUND</description>
+      <type>image</type>
+      <id>0</id>
+      <posX>0</posX>
+      <posY>0</posY>
+      <width>1920</width>
+      <height>1080</height>
+      <texture>background.png</texture>
+      <shouldCache>true</shouldCache>
+    </control>
+
+    <import>Trakt.Common.Fanart.xml</import>
+
+    <!--            :: BACKGROUNDS ::           	 -->
+
+    <control>
+      <description>background listview</description>
+      <type>image</type>
+      <id>0</id>
+      <posX>0</posX>
+      <posY>0</posY>
+      <width>1920</width>
+      <height>1080</height>
+      <texture>fanart_overlay.png</texture>
+      <visible>[facadeview.list | facadeview.smallicons | facadeview.largeicons | facadeview.filmstrip | facadeview.coverflow] + Control.IsVisible(50)</visible>
+      <animation effect="fade" time="250">WindowOpen</animation>
+      <animation effect="fade" time="250">WindowClose</animation>
+    </control>
+
+    <control>
+      <description>background listview</description>
+      <type>image</type>
+      <id>0</id>
+      <posX>10</posX>
+      <posY>252</posY>
+      <width>1903</width>
+      <height>790</height>
+      <texture>panel_list.png</texture>
+      <visible>facadeview.list + Control.IsVisible(50)</visible>
+      <animation effect="fade" time="250">WindowOpen</animation>
+      <animation effect="fade" time="250">WindowClose</animation>
+    </control>
+
+    <control>
+      <description>background thumbs</description>
+      <type>image</type>
+      <id>0</id>
+      <posX>10</posX>
+      <posY>252</posY>
+      <width>1903</width>
+      <height>790</height>
+      <texture>panel_tvseries_widebanner.6x2.png</texture>
+      <visible>[facadeview.smallicons | facadeview.largeicons] + Control.IsVisible(50)</visible>
+      <animation effect="fade" time="250">WindowOpen</animation>
+      <animation effect="fade" time="250">WindowClose</animation>
+    </control>
+
+    <control>
+      <description>filmstrip overlay</description>
+      <type>image</type>
+      <id>0</id>
+      <posX>0</posX>
+      <posY>279</posY>
+      <width>1920</width>
+      <height>801</height>
+      <texture>filmstrip_overlay.png</texture>
+      <visible>[facadeview.filmstrip | facadeview.coverflow] + Control.IsVisible(50)</visible>
+      <animation effect="fade" time="250">WindowOpen</animation>
+      <animation effect="fade" time="250">WindowClose</animation>
+    </control>
+
+    <control>
+      <description>filmstrip overlay</description>
+      <type>image</type>
+      <id>0</id>
+      <posX>52</posX>
+      <posY>958</posY>
+      <width>1820</width>
+      <height>84</height>
+      <texture>BasicHomeSubBG.png</texture>
+      <visible>[facadeview.filmstrip | facadeview.coverflow] + Control.IsVisible(50)</visible>
+      <animation effect="fade" time="250">WindowOpen</animation>
+      <animation effect="fade" time="250">WindowClose</animation>
+    </control>
+
+    <control>
+      <id>0</id>
+      <type>image</type>
+      <posX>66</posX>
+      <posY>34</posY>
+      <width>61</width>
+      <height>60</height>
+      <texture>icon_series.png</texture>
+      <animation effect="fade" time="250">WindowOpen</animation>
+      <animation effect="fade" time="250">WindowClose</animation>
+    </control>
+    <import>common.time.xml</import>
+    <control>
+      <description>Current View</description>
+      <type>label</type>
+      <label>Trakt</label>
+      <id>0</id>
+      <posX>144</posX>
+      <posY>94</posY>
+      <align>left</align>
+      <textcolor>FFFFFFFF</textcolor>
+      <font>TitanLight12</font>
+      <animation effect="fade" time="250">WindowOpen</animation>
+      <animation effect="fade" time="250">WindowClose</animation>
+    </control>
+
+    <!--            :: Count ::            -->
+
+    <control>
+      <description>Moviecount</description>
+      <type>label</type>
+      <label>#Trakt.Translation.Series.Label: #itemcount</label>
+      <id>0</id>
+      <posX>96</posX>
+      <posY>998</posY>
+      <align>left</align>
+      <font>TitanLight12</font>
+      <textcolor>000000</textcolor>
+      <visible>[facadeview.list | facadeview.smallicons | facadeview.largeicons | facadeview.filmstrip | facadeview.coverflow] + control.isvisible(50)</visible>
+      <animation effect="fade" time="250">WindowOpen</animation>
+      <animation effect="fade" time="250">WindowClose</animation>
+    </control>
+
+    <!--            :: Listview Lines ::            -->
+
+    <control>
+      <description>List Lines</description>
+      <type>image</type>
+      <id>1</id>
+      <posX>1222</posX>
+      <posY>385</posY>
+      <width>607</width>
+      <height>506</height>
+      <texture>list_lines.png</texture>
+      <visible>facadeview.list + control.isvisible(50)</visible>
+      <animation effect="fade" time="250">WindowOpen</animation>
+      <animation effect="fade" time="250">WindowClose</animation>
+    </control>
+
+    <control>
+      <description>group element</description>
+      <type>group</type>
+      <animation effect="fade" time="250">WindowOpen</animation>
+      <animation effect="fade" time="250">WindowClose</animation>
+      <control>
+        <type>facadeview</type>
+        <id>50</id>
+        <control>
+          <description>Movie List</description>
+          <type>listcontrol</type>
+          <id>50</id>
+          <onleft>2</onleft>
+          <onright>2</onright>
+          <scrollOffset>1</scrollOffset>
+          <posX>1165</posX>
+          <posY>331</posY>
+          <height>700</height>
+          <width>698</width>
+          <textXOff>44</textXOff>
+          <textXOff2>650</textXOff2>
+          <textureHeight>54</textureHeight>
+          <textureFocus>listcontrol_item_selected.png</textureFocus>
+          <textureNoFocus>-</textureNoFocus>
+          <dimColor>ffffffff</dimColor>
+          <spinPosX>1828</spinPosX>
+          <spinPosY>1000</spinPosY>
+        </control>
+
+        <control>
+          <description>Filmstrip view</description>
+          <type>filmstrip</type>
+          <dimColor>90ffffff</dimColor>
+          <id>50</id>
+          <scrollOffset>3</scrollOffset>
+          <folderPrefix></folderPrefix>
+          <folderSuffix></folderSuffix>
+          <posX>130</posX>
+          <posY>595</posY>
+          <width>1700</width>
+          <height>340</height>
+          <onup>2</onup>
+          <ondown>2</ondown>
+          <onleft>50</onleft>
+          <onright>50</onright>
+          <thumbWidth>230</thumbWidth>
+          <thumbHeight>327</thumbHeight>
+          <thumbPosX>0</thumbPosX>
+          <thumbPosY>0</thumbPosY>
+          <itemWidth>240</itemWidth>
+          <itemHeight>327</itemHeight>
+          <textureWidth>230</textureWidth>
+          <textureHeight>327</textureHeight>
+          <textYOff>-2000</textYOff>
+          <imageFolderFocus>-</imageFolderFocus>
+          <frame>-</frame>
+          <frameFocus>-</frameFocus>
+          <background>-</background>
+          <thumbs flipY="true" diffuse="Thumb_Mask_test.png" mask="filmstrip_mask.png"></thumbs>
+          <showFrame>yes</showFrame>
+          <showFolder>no</showFolder>
+          <showBackGround>no</showBackGround>
+          <showInfoImage>no</showInfoImage>
+          <scrollbarBackground>scrollbar_bg_hor.png</scrollbarBackground>
+          <scrollbarLeft>scrollbar_left_hor.png</scrollbarLeft>
+          <scrollbarRight>scrollbar_right_hor.png</scrollbarRight>
+          <scrollbarWidth>717</scrollbarWidth>
+          <scrollbarHeight>8</scrollbarHeight>
+          <scrollbarYOff>375</scrollbarYOff>
+          <keepaspectratio>no</keepaspectratio>
+          <thumbAnimation effect="zoom" acceleration="-2" start="100,100" reversible="false" end="120,120" center="0,880" time="200">focus</thumbAnimation>
+          <thumbAnimation effect="zoom" start="120,120" reversible="false" end="100,100" center="0,880" time="100">unfocus</thumbAnimation>
+        </control>
+
+        <control>
+          <description>Thumbnail Panel</description>
+          <type>thumbnailpanel</type>
+          <id>50</id>
+          <posX>754</posX>
+          <posY>342</posY>
+          <width>1150</width>
+          <height>700</height>
+          <folderPrefix></folderPrefix>
+          <folderSuffix></folderSuffix>
+          <onleft>2</onleft>
+          <onright>2</onright>
+          <itemWidth>138</itemWidth>
+          <itemHeight>196</itemHeight>
+          <textureWidth>138</textureWidth>
+          <textureHeight>196</textureHeight>
+          <thumbWidth>128</thumbWidth>
+          <thumbHeight>186</thumbHeight>
+          <thumbPosX>6</thumbPosX>
+          <thumbPosY>5</thumbPosY>
+          <itemWidthBig>214</itemWidthBig>
+          <itemHeightBig>304</itemHeightBig>
+          <thumbWidthBig>204</thumbWidthBig>
+          <thumbHeightBig>294</thumbHeightBig>
+          <textureWidthBig>216</textureWidthBig>
+          <textureHeightBig>304</textureHeightBig>
+          <thumbPosXBig>6</thumbPosXBig>
+          <thumbPosYBig>5</thumbPosYBig>
+          <zoomXPixels>0</zoomXPixels>
+          <zoomYPixels>0</zoomYPixels>
+          <hideUnfocusTexture>no</hideUnfocusTexture>
+          <keepaspectratio>no</keepaspectratio>
+          <renderFocusText>no</renderFocusText>
+          <renderUnfocusText>no</renderUnfocusText>
+          <frameNoFocus>-</frameNoFocus>
+          <frameFocus>video_thumb_focus.png</frameFocus>
+          <textureMask></textureMask>
+          <shadowAngle>90</shadowAngle>
+          <shadowDistance>50</shadowDistance>
+          <thumbZoom>no</thumbZoom>
+          <spinPosX>1828</spinPosX>
+          <spinPosY>1000</spinPosY>
+          <unfocusedAlpha>100</unfocusedAlpha>
+        </control>
+
+        <control>
+          <description>Cover Flow view</description>
+          <type>coverflow</type>
+          <colordiffuse>90ffffff</colordiffuse>
+          <dimColor>90ffffff</dimColor>
+          <id>50</id>
+          <onup>2</onup>
+          <ondown>2</ondown>
+          <onleft>50</onleft>
+          <onright>50</onright>
+          <posX>0</posX>
+          <posY>595</posY>
+          <width>1920</width>
+          <height>340</height>
+          <selectedCard>0</selectedCard>
+          <cardWidth>238</cardWidth>
+          <cardHeight>340</cardHeight>
+          <angle>55</angle>
+          <sideShift>150</sideShift>
+          <sideGap>120</sideGap>
+          <sideDepth>110</sideDepth>
+          <offsetY>0</offsetY>
+          <selectedOffsetY>0</selectedOffsetY>
+          <speed>10</speed>
+          <showFrame>yes</showFrame>
+          <frame>-</frame>
+          <frameFocus>-</frameFocus>
+          <keepaspectratio>no</keepaspectratio>
+          <frameWidth>238</frameWidth>
+          <frameHeight>340</frameHeight>
+          <spinSpeed>8</spinSpeed>
+          <unfocusedAlpha>FF</unfocusedAlpha>
+          <folderPrefix></folderPrefix>
+          <folderSuffix></folderSuffix>
+          <font1>font13</font1>
+          <font2>font11</font2>
+          <label1>#title</label1>
+          <label2>#genre</label2>
+          <textColor>FFFFFFFF</textColor>
+          <remoteColor>FFFF0000</remoteColor>
+          <playedColor>FFA0D0FF</playedColor>
+          <downloadColor>FF00FF00</downloadColor>
+          <selectedColor>FFFFFFFF</selectedColor>
+          <shadowAngle>45</shadowAngle>
+          <shadowDistance>1</shadowDistance>
+          <shadowColor>FF000000</shadowColor>
+          <label1YOff>1430</label1YOff>
+          <label2YOff>1390</label2YOff>
+          <pageSize>5</pageSize>
+          <scrollbarBackground>scrollbar_bg_hor.png</scrollbarBackground>
+          <scrollbarLeft>scrollbar_left_hor.png</scrollbarLeft>
+          <scrollbarRight>scrollbar_right_hor.png</scrollbarRight>
+          <scrollbarWidth>717</scrollbarWidth>
+          <scrollbarHeight>8</scrollbarHeight>
+          <scrollbarYOff>375</scrollbarYOff>
+          <cards flipY="true" diffuse="Thumb_Mask_test.png" mask="filmstrip_mask.png"></cards>
+        </control>
+      </control>
+    </control>
+
+    <!--            :: HIDDEN MENU ::           	 -->
+
+    <control>
+      <id>1</id>
+      <type>image</type>
+      <posX>0</posX>
+      <posY>440</posY>
+      <width>64</width>
+      <height>199</height>
+      <texture>hiddenmenu_tab.png</texture>
+      <visible>[facadeview.list | facadeview.smallicons | facadeview.largeicons]+Control.HasFocus(50) + !string.contains(#Titan.HiddenMenu, false)</visible>
+      <animation effect="slide" start="-60,0" end="0,0" tween="quadratic" easing="in" time="250" delay="400">WindowOpen</animation>
+      <animation effect="slide" start="0,0" end="-60,0" tween="quadratic" easing="in" time="250" delay="100">WindowClose</animation>
+    </control>
+
+    <control>
+      <id>1</id>
+      <type>image</type>
+      <posX>858</posX>
+      <posY>0</posY>
+      <texture>hiddenmenu_tab_up.png</texture>
+      <visible>[facadeview.filmstrip | facadeview.coverflow] + Control.HasFocus(50) + !string.contains(#Titan.HiddenMenu, false)</visible>
+      <animation effect="slide" start="0,-60" end="0,0" tween="quadratic" easing="in" time="250" delay="400">WindowOpen</animation>
+      <animation effect="slide" start="0,0" end="0,-60" tween="quadratic" easing="in" time="250" delay="100">WindowClose</animation>
+    </control>
+
+    <control>
+      <type>actiongroup</type>
+      <description>action menu</description>
+      <defaultcontrol>3</defaultcontrol>
+      <onexit>50</onexit>
+      <dimColor>00ffffff</dimColor>
+      <buttonX>-460</buttonX>
+      <buttonY>155</buttonY>
+      <buttonwidth>499</buttonwidth>
+      <buttonheight>1080</buttonheight>
+
+      <control>
+        <type>image</type>
+        <id>0</id>
+        <width>1920</width>
+        <height>1080</height>
+        <texture>semi_trans_back_hidden_menu.png</texture>
+        <visible>!Control.HasFocus(50)+control.isvisible(50)</visible>
+        <animation effect="fade" time="450">visible</animation>
+        <animation effect="fade" time="400">hidden</animation>
+      </control>
+
+      <control>
+        <type>image</type>
+        <id>0</id>
+        <posY>0</posY>
+        <posX>0</posX>
+        <width>612</width>
+        <height>1074</height>
+        <texture>menu_bg.png</texture>
+        <visible>!Control.HasFocus(50)+control.isvisible(50)</visible>
+        <animation effect="fade" time="0">WindowClose</animation>
+        <animation effect="slide" start="-150,0" time="100">visible</animation>
+        <animation effect="fade" time="50">visible</animation>
+        <animation effect="fade" time="0">hidden</animation>
+      </control>
+      <control>
+        <type>image</type>
+        <id>0</id>
+        <posY>375</posY>
+        <posX>116</posX>
+        <width>369</width>
+        <height>1</height>
+        <texture>hiddenmenu_separator.png</texture>
+        <visible>!Control.HasFocus(50)+control.isvisible(50)</visible>
+        <animation effect="fade" time="0">WindowClose</animation>
+        <animation effect="slide" start="-150,0" time="100">visible</animation>
+        <animation effect="fade" time="50">visible</animation>
+        <animation effect="fade" time="0">hidden</animation>
+      </control>
+      <control>
+        <description>Menu label</description>
+        <type>label</type>
+        <id>1</id>
+        <posX>116</posX>
+        <posY>100</posY>
+        <label>924</label>
+        <font>fontB16</font>
+        <textcolor>393939</textcolor>
+        <visible>!Control.HasFocus(50)+control.isvisible(50)</visible>
+        <animation effect="fade" time="0">WindowClose</animation>
+        <animation effect="slide" start="-150,0" time="100">visible</animation>
+        <animation effect="fade" time="50">visible</animation>
+        <animation effect="fade" time="0">hidden</animation>
+      </control>
+      <control>
+        <description>Settings label</description>
+        <type>label</type>
+        <id>1</id>
+        <posX>116</posX>
+        <posY>385</posY>
+        <label>496</label>
+        <font>fontB12</font>
+        <textcolor>393939</textcolor>
+        <visible>!Control.HasFocus(50)+control.isvisible(50)</visible>
+        <animation effect="fade" time="0">WindowClose</animation>
+        <animation effect="slide" start="-150,0" time="100">visible</animation>
+        <animation effect="fade" time="50">visible</animation>
+        <animation effect="fade" time="0">hidden</animation>
+      </control>
+      <control>
+        <type>group</type>
+        <description>group element</description>
+        <visible>!Control.HasFocus(50)+control.isvisible(50)</visible>
+        <animation effect="fade" time="0">WindowClose</animation>
+        <animation effect="slide" start="-150,0" time="100">visible</animation>
+        <animation effect="fade" time="50">visible</animation>
+        <animation effect="fade" time="0">hidden</animation>
+        <posX>53</posX>
+        <posY>155</posY>
+        <layout>StackLayout(0, Vertical, true)</layout>
+
+        <control>
+          <description>Change Layout</description>
+          <type>button</type>
+          <id>2</id>
+          <textureFocus>hiddenmenu_item_selected.png</textureFocus>
+          <textureNoFocus>-</textureNoFocus>
+          <width>499</width>
+          <height>69</height>
+          <textXOff>62</textXOff>
+          <textYOff>16</textYOff>
+          <label>-</label>
+          <onright>50</onright>
+          <ondown>8</ondown>
+          <onup>7</onup>
+        </control>
+
+        <control>
+          <description>Sort</description>
+          <type>sortbutton</type>
+          <id>8</id>
+          <label>-</label>
+          <textureFocus>hiddenmenu_item_selected.png</textureFocus>
+          <textureNoFocus>-</textureNoFocus>
+          <width>499</width>
+          <height>69</height>
+          <textXOff>62</textXOff>
+          <textYOff>16</textYOff>
+          <offsetSortButtonX>421</offsetSortButtonX>
+          <offsetSortButtonY>27</offsetSortButtonY>
+          <onright>50</onright>
+          <onleft>50</onleft>
+          <ondown>3</ondown>
+          <onup>2</onup>
+        </control>
+
+        <control>
+          <description>Genres</description>
+          <type>button</type>
+          <id>3</id>
+          <label>-</label>
+          <onleft>50</onleft>
+          <onright>50</onright>
+          <textureFocus>hiddenmenu_item_selected.png</textureFocus>
+          <textureNoFocus>-</textureNoFocus>
+          <width>499</width>
+          <height>69</height>
+          <textXOff>62</textXOff>
+          <textYOff>16</textYOff>
+          <ondown>4</ondown>
+          <onup>8</onup>
+        </control>
+
+        <control>
+          <description>Empty button</description>
+          <type>button</type>
+          <id>0</id>
+          <textureFocus>-</textureFocus>
+          <textureNoFocus>-</textureNoFocus>
+          <width>499</width>
+          <height>69</height>
+          <label>-</label>
+          <visible>true</visible>
+        </control>
+
+        <control>
+          <description>Toggle Hide Collected</description>
+          <type>checkbutton</type>
+          <id>4</id>
+          <label>#Trakt.Translation.HideCollected.Label</label>
+          <textureFocus>hiddenmenu_item_selected.png</textureFocus>
+          <textureNoFocus>-</textureNoFocus>
+          <textcolor>FFFFFFFF</textcolor>
+          <textcolorNoFocus>ff393939</textcolorNoFocus>
+          <width>499</width>
+          <height>69</height>
+          <textXOff>62</textXOff>
+          <textYOff>16</textYOff>
+          <markXOff>38</markXOff>
+          <onleft>50</onleft>
+          <onright>50</onright>
+          <ondown>5</ondown>
+          <onup>3</onup>
+        </control>
+        <control>
+          <description>Toggle Hide Watchlisted</description>
+          <type>checkbutton</type>
+          <id>5</id>
+          <label>#Trakt.Translation.HideWatchlisted.Label</label>
+          <textureFocus>hiddenmenu_item_selected.png</textureFocus>
+          <textureNoFocus>-</textureNoFocus>
+          <textcolor>FFFFFFFF</textcolor>
+          <textcolorNoFocus>ff393939</textcolorNoFocus>
+          <width>499</width>
+          <height>69</height>
+          <textXOff>62</textXOff>
+          <textYOff>16</textYOff>
+          <markXOff>38</markXOff>
+          <onleft>50</onleft>
+          <onright>50</onright>
+          <ondown>6</ondown>
+          <onup>4</onup>
+        </control>
+        <control>
+          <description>Start Year</description>
+          <type>button</type>
+          <id>6</id>
+          <label>-</label>
+          <onleft>50</onleft>
+          <onright>50</onright>
+          <textureFocus>hiddenmenu_item_selected.png</textureFocus>
+          <textureNoFocus>-</textureNoFocus>
+          <width>499</width>
+          <height>69</height>
+          <textXOff>62</textXOff>
+          <textYOff>16</textYOff>
+          <ondown>7</ondown>
+          <onup>5</onup>
+        </control>
+        <control>
+          <description>End Year</description>
+          <type>button</type>
+          <id>7</id>
+          <label>-</label>
+          <onleft>50</onleft>
+          <onright>50</onright>
+          <textureFocus>hiddenmenu_item_selected.png</textureFocus>
+          <textureNoFocus>-</textureNoFocus>
+          <width>499</width>
+          <height>69</height>
+          <textXOff>62</textXOff>
+          <textYOff>16</textYOff>
+          <ondown>2</ondown>
+          <onup>6</onup>
+        </control>
+      </control>
+    </control>
+
+    <import>Trakt.Common.Shows.xml</import>
+    <import>common.overlay.xml</import>
+  </controls>
+</window>

--- a/Common/Trakt.Season.Episodes.xml
+++ b/Common/Trakt.Season.Episodes.xml
@@ -1,0 +1,428 @@
+<?xml version="1.0" encoding="utf-8" standalone="yes"?>
+<window>
+  <id>87282</id>
+  <defaultcontrol>50</defaultcontrol>
+  <allowoverlay>no</allowoverlay>
+  <define>#header.label:#Trakt.Translation.Episodes.Label</define>
+  <controls>
+
+    <control>
+      <description>DEFAULT BACKGROUND</description>
+      <type>image</type>
+      <id>0</id>
+      <posX>0</posX>
+      <posY>0</posY>
+      <width>1920</width>
+      <height>1080</height>
+      <texture>background.png</texture>
+      <shouldCache>true</shouldCache>
+    </control>
+
+    <control>
+      <id>1</id>
+      <description>Fanart Image</description>
+      <type>image</type>
+      <posX>0</posX>
+      <posY>0</posY>
+      <width>1920</width>
+      <height>1080</height>
+      <texture>#Trakt.Show.Fanart</texture>
+    </control>
+
+    <!--            :: BACKGROUNDS ::           	 -->
+    <control>
+      <description>background listview</description>
+      <type>image</type>
+      <id>0</id>
+      <posX>0</posX>
+      <posY>0</posY>
+      <width>1920</width>
+      <height>1080</height>
+      <texture>fanart_overlay.png</texture>
+      <animation effect="fade" time="250">WindowOpen</animation>
+      <animation effect="fade" time="250">WindowClose</animation>
+    </control>
+
+    <control>
+      <description>background listview</description>
+      <type>image</type>
+      <id>0</id>
+      <posX>10</posX>
+      <posY>252</posY>
+      <width>1903</width>
+      <height>790</height>
+      <texture>panel_list.png</texture>
+      <visible>facadeview.list + Control.IsVisible(50)</visible>
+      <animation effect="fade" time="250">WindowOpen</animation>
+      <animation effect="fade" time="250">WindowClose</animation>
+    </control>
+
+    <control>
+      <description>background thumbs</description>
+      <type>image</type>
+      <id>0</id>
+      <posX>10</posX>
+      <posY>252</posY>
+      <width>1903</width>
+      <height>790</height>
+      <texture>panel_tvseries_widebanner.6x2.png</texture>
+      <visible>[facadeview.smallicons | facadeview.largeicons] + Control.IsVisible(50)</visible>
+      <animation effect="fade" time="250">WindowOpen</animation>
+      <animation effect="fade" time="250">WindowClose</animation>
+    </control>
+
+    <control>
+      <description>filmstrip overlay</description>
+      <type>image</type>
+      <id>0</id>
+      <posX>0</posX>
+      <posY>279</posY>
+      <width>1920</width>
+      <height>801</height>
+      <texture>filmstrip_overlay.png</texture>
+      <visible>[facadeview.filmstrip | facadeview.coverflow] + Control.IsVisible(50)</visible>
+      <animation effect="fade" time="250">WindowOpen</animation>
+      <animation effect="fade" time="250">WindowClose</animation>
+    </control>
+
+    <control>
+      <description>filmstrip overlay</description>
+      <type>image</type>
+      <id>0</id>
+      <posX>52</posX>
+      <posY>958</posY>
+      <width>1820</width>
+      <height>84</height>
+      <texture>BasicHomeSubBG.png</texture>
+      <visible>[facadeview.filmstrip | facadeview.coverflow] + Control.IsVisible(50)</visible>
+      <animation effect="fade" time="250">WindowOpen</animation>
+      <animation effect="fade" time="250">WindowClose</animation>
+    </control>
+
+    <control>
+      <id>0</id>
+      <type>image</type>
+      <posX>66</posX>
+      <posY>34</posY>
+      <width>61</width>
+      <height>60</height>
+      <texture>icon_series.png</texture>
+      <animation effect="fade" time="250">WindowOpen</animation>
+      <animation effect="fade" time="250">WindowClose</animation>
+    </control>
+
+    <import>common.time.xml</import>
+    <control>
+      <description>Current Show</description>
+      <type>label</type>
+      <label>#Trakt.Show.Title</label>
+      <id>0</id>
+      <posX>144</posX>
+      <posY>94</posY>
+      <align>left</align>
+      <textcolor>FFFFFFFF</textcolor>
+      <font>TitanLight12</font>
+      <animation effect="fade" time="250">WindowOpen</animation>
+      <animation effect="fade" time="250">WindowClose</animation>
+    </control>
+
+    <!--            :: List Scrolling Popup ::            -->
+
+    <control>
+      <description>listscroller bg</description>
+      <type>image</type>
+      <id>1</id>
+      <posX>210</posX>
+      <posY>542</posY>
+      <width>211</width>
+      <height>211</height>
+      <texture>listscroller_bg.png</texture>
+      <visible>facadeview.list+string.contains(#scrolling.up,yes)|string.contains(#scrolling.down,yes)</visible>
+      <animation effect="fade" time="250">Visible</animation>
+      <animation effect="fade" time="0">Hidden</animation>
+    </control>
+
+    <control>
+      <type>label</type>
+      <id>1</id>
+      <posX>265</posX>
+      <posY>602</posY>
+      <width>96</width>
+      <height>96</height>
+      <font>TitanLight32</font>
+      <textcolor>ff000000</textcolor>
+      <label>#selecteditem.scrolllabel</label>
+      <visible>facadeview.list+string.contains(#scrolling.up,yes)|string.contains(#scrolling.down,yes)</visible>
+      <align>center</align>
+      <valign>middle</valign>
+      <animation effect="fade" time="250">Visible</animation>
+      <animation effect="fade" time="0">Hidden</animation>
+    </control>
+
+    <!--            :: Count ::            -->
+
+    <control>
+      <description>Moviecount</description>
+      <type>label</type>
+      <label>#Trakt.Translation.Episodes.Label: #itemcount</label>
+      <id>0</id>
+      <posX>96</posX>
+      <posY>998</posY>
+      <align>left</align>
+      <font>TitanLight12</font>
+      <textcolor>000000</textcolor>
+      <visible>[facadeview.list | facadeview.smallicons | facadeview.largeicons | facadeview.filmstrip | facadeview.coverflow] + control.isvisible(50)</visible>
+      <animation effect="fade" time="250">WindowOpen</animation>
+      <animation effect="fade" time="250">WindowClose</animation>
+    </control>
+
+    <!--            :: Listview Lines ::            -->
+
+    <control>
+      <description>List Lines</description>
+      <type>image</type>
+      <id>1</id>
+      <posX>1222</posX>
+      <posY>385</posY>
+      <width>607</width>
+      <height>506</height>
+      <texture>list_lines.png</texture>
+      <visible>facadeview.list + control.isvisible(50)</visible>
+      <animation effect="fade" time="250">WindowOpen</animation>
+      <animation effect="fade" time="250">WindowClose</animation>
+    </control>
+
+    <control>
+      <description>group element</description>
+      <type>group</type>
+      <animation effect="fade" time="250">WindowOpen</animation>
+      <animation effect="fade" time="250">WindowClose</animation>
+      <control>
+        <type>facadeview</type>
+        <id>50</id>
+        <control>
+          <description>Episode List</description>
+          <type>listcontrol</type>
+          <id>50</id>
+          <onleft>2</onleft>
+          <onright>2</onright>
+          <scrollOffset>1</scrollOffset>
+          <posX>1165</posX>
+          <posY>331</posY>
+          <height>700</height>
+          <width>698</width>
+          <textXOff>44</textXOff>
+          <textXOff2>650</textXOff2>
+          <textureHeight>54</textureHeight>
+          <textureFocus>listcontrol_item_selected.png</textureFocus>
+          <textureNoFocus>-</textureNoFocus>
+          <dimColor>ffffffff</dimColor>
+          <spinPosX>1828</spinPosX>
+          <spinPosY>1000</spinPosY>
+          <explicitlyEnableScrollLabel>no</explicitlyEnableScrollLabel>
+        </control>
+
+        <control>
+          <description>Filmstrip view</description>
+          <type>filmstrip</type>
+          <dimColor>90ffffff</dimColor>
+          <id>50</id>
+          <scrollOffset>3</scrollOffset>
+          <folderPrefix></folderPrefix>
+          <folderSuffix></folderSuffix>
+          <posX>88</posX>
+          <posY>665</posY>
+          <width>1800</width>
+          <height>340</height>
+          <onup>2</onup>
+          <ondown>2</ondown>
+          <onleft>50</onleft>
+          <onright>50</onright>
+          <thumbWidth>338</thumbWidth>
+          <thumbHeight>190</thumbHeight>
+          <thumbPosX>0</thumbPosX>
+          <thumbPosY>0</thumbPosY>
+          <itemWidth>353</itemWidth>
+          <itemHeight>190</itemHeight>
+          <textureWidth>338</textureWidth>
+          <textureHeight>190</textureHeight>
+          <textYOff>-2000</textYOff>
+          <imageFolderFocus>-</imageFolderFocus>
+          <frame>-</frame>
+          <frameFocus>-</frameFocus>
+          <background>-</background>
+          <thumbs flipY="true" diffuse="Thumb_Mask.png" mask="pictures_filmstrip_mask.png"></thumbs>
+          <showFrame>yes</showFrame>
+          <showFolder>no</showFolder>
+          <showBackGround>no</showBackGround>
+          <showInfoImage>no</showInfoImage>
+          <keepaspectratio>no</keepaspectratio>
+          <scrollbarBackground>scrollbar_bg_hor.png</scrollbarBackground>
+          <scrollbarLeft>scrollbar_left_hor.png</scrollbarLeft>
+          <scrollbarRight>scrollbar_right_hor.png</scrollbarRight>
+          <scrollbarWidth>717</scrollbarWidth>
+          <scrollbarHeight>8</scrollbarHeight>
+          <scrollbarYOff>293</scrollbarYOff>
+          <spinPosX>1828</spinPosX>
+          <spinPosY>1000</spinPosY>
+          <thumbAnimation effect="zoom" acceleration="-2" start="100,100" reversible="false" end="135,135" center="0,800" time="200">focus</thumbAnimation>
+          <thumbAnimation effect="zoom" start="135,135" reversible="false" end="100,100" center="0,800" time="100">unfocus</thumbAnimation>
+        </control>
+
+        <control>
+          <description>Thumbnail Panel</description>
+          <type>thumbnailpanel</type>
+          <id>50</id>
+          <posX>754</posX>
+          <posY>324</posY>
+          <width>1150</width>
+          <height>700</height>
+          <onleft>2</onleft>
+          <onright>50</onright>
+          <imageFolder>-</imageFolder>
+          <imageFolderFocus>-</imageFolderFocus>
+          <showFrame>true</showFrame>
+          <dimColor>70ffffff</dimColor>
+          <enableFocusZoom>no</enableFocusZoom>
+          <hideUnfocusTexture>no</hideUnfocusTexture>
+          <renderFocusText>no</renderFocusText>
+          <renderUnfocusText>no</renderUnfocusText>
+          <thumbZoom>no</thumbZoom>
+          <frameNoFocus>-</frameNoFocus>
+          <frameFocus>onlinevideos_thumb_focus.png</frameFocus>
+          <textureMask></textureMask>
+          <itemWidth>217</itemWidth>
+          <itemHeight>126</itemHeight>
+          <textureWidth>217</textureWidth>
+          <textureHeight>126</textureHeight>
+          <thumbWidth>205</thumbWidth>
+          <thumbHeight>116</thumbHeight>
+          <thumbPosX>6</thumbPosX>
+          <thumbPosY>5</thumbPosY>
+          <itemWidthBig>275</itemWidthBig>
+          <itemHeightBig>160</itemHeightBig>
+          <thumbWidthBig>258</thumbWidthBig>
+          <thumbHeightBig>147</thumbHeightBig>
+          <textureWidthBig>275</textureWidthBig>
+          <textureHeightBig>160</textureHeightBig>
+          <thumbPosXBig>8</thumbPosXBig>
+          <thumbPosYBig>6</thumbPosYBig>
+          <zoomXPixels>0</zoomXPixels>
+          <zoomYPixels>0</zoomYPixels>
+          <spinPosX>1828</spinPosX>
+          <spinPosY>1000</spinPosY>
+          <keepaspectratio>no</keepaspectratio>
+          <unfocusedAlpha>100</unfocusedAlpha>
+        </control>
+      </control>
+    </control>
+
+    <!--            :: HIDDEN MENU ::           	 -->
+
+    <control>
+      <id>1</id>
+      <type>image</type>
+      <posX>0</posX>
+      <posY>440</posY>
+      <width>64</width>
+      <height>199</height>
+      <texture>hiddenmenu_tab.png</texture>
+      <visible>[facadeview.list | facadeview.smallicons | facadeview.largeicons]+Control.HasFocus(50) + !string.contains(#Titan.HiddenMenu, false)</visible>
+      <animation effect="slide" start="-60,0" end="0,0" tween="quadratic" easing="in" time="250" delay="400">WindowOpen</animation>
+      <animation effect="slide" start="0,0" end="-60,0" tween="quadratic" easing="in" time="250" delay="100">WindowClose</animation>
+    </control>
+
+    <control>
+      <id>1</id>
+      <type>image</type>
+      <posX>858</posX>
+      <posY>0</posY>
+      <texture>hiddenmenu_tab_up.png</texture>
+      <visible>[facadeview.filmstrip | facadeview.coverflow] + Control.HasFocus(50) + !string.contains(#Titan.HiddenMenu, false)</visible>
+      <animation effect="slide" start="0,-60" end="0,0" tween="quadratic" easing="in" time="250" delay="400">WindowOpen</animation>
+      <animation effect="slide" start="0,0" end="0,-60" tween="quadratic" easing="in" time="250" delay="100">WindowClose</animation>
+    </control>
+
+    <control>
+      <type>actiongroup</type>
+      <description>action menu</description>
+      <defaultcontrol>3</defaultcontrol>
+      <onexit>50</onexit>
+      <dimColor>00ffffff</dimColor>
+      <buttonX>0</buttonX>
+      <buttonY>0</buttonY>
+      <buttonwidth>521</buttonwidth>
+      <buttonheight>1080</buttonheight>
+
+      <control>
+        <type>image</type>
+        <id>0</id>
+        <width>1920</width>
+        <height>1080</height>
+        <texture>semi_trans_back_hidden_menu.png</texture>
+        <visible>!Control.HasFocus(50)+control.isvisible(50)</visible>
+        <animation effect="fade" time="450">visible</animation>
+        <animation effect="fade" time="400">hidden</animation>
+      </control>
+
+      <control>
+        <type>image</type>
+        <id>0</id>
+        <posY>0</posY>
+        <posX>0</posX>
+        <width>612</width>
+        <height>1074</height>
+        <texture>menu_bg.png</texture>
+        <visible>!Control.HasFocus(50)+control.isvisible(50)</visible>
+        <animation effect="fade" time="0">WindowClose</animation>
+        <animation effect="slide" start="-150,0" time="100">visible</animation>
+        <animation effect="fade" time="50">visible</animation>
+        <animation effect="fade" time="0">hidden</animation>
+      </control>
+
+      <control>
+        <description>Menu label</description>
+        <type>label</type>
+        <id>1</id>
+        <posX>116</posX>
+        <posY>100</posY>
+        <label>924</label>
+        <font>fontB16</font>
+        <textcolor>393939</textcolor>
+        <visible>!Control.HasFocus(50)+control.isvisible(50)</visible>
+        <animation effect="fade" time="0">WindowClose</animation>
+        <animation effect="slide" start="-150,0" time="100">visible</animation>
+        <animation effect="fade" time="50">visible</animation>
+        <animation effect="fade" time="0">hidden</animation>
+      </control>
+      <control>
+        <type>group</type>
+        <description>group element</description>
+        <visible>!Control.HasFocus(50)+control.isvisible(50)</visible>
+        <animation effect="fade" time="0">WindowClose</animation>
+        <animation effect="slide" start="-150,0" time="100">visible</animation>
+        <animation effect="fade" time="50">visible</animation>
+        <animation effect="fade" time="0">hidden</animation>
+        <posX>53</posX>
+        <posY>155</posY>
+        <layout>StackLayout(0, Vertical, true)</layout>
+
+        <control>
+          <description>Change Layout</description>
+          <type>button</type>
+          <id>2</id>
+          <textureFocus>hiddenmenu_item_selected.png</textureFocus>
+          <textureNoFocus>-</textureNoFocus>
+          <width>499</width>
+          <height>69</height>
+          <textXOff>62</textXOff>
+          <textYOff>16</textYOff>
+          <label>-</label>
+          <onright>50</onright>
+        </control>
+      </control>
+    </control>
+    <import>Trakt.Common.Episodes.xml</import>
+    <import>common.overlay.xml</import>
+  </controls>
+</window>

--- a/Common/Trakt.Show.Seasons.xml
+++ b/Common/Trakt.Show.Seasons.xml
@@ -28,7 +28,7 @@
         <posY>150</posY>
         <width>250</width>
         <height>140</height>
-        <texture>#fanarthandler.series.clearart.selected</texture>
+        <texture>#fanarthandler.tvseries.clearart.selected</texture>
         <animation effect="fade" time="250">WindowOpen</animation>
         <animation effect="fade" time="250">WindowClose</animation>
     </control>  
@@ -43,7 +43,7 @@
         <width>250</width>
         <height>140</height>
         <visible>!control.hasthumb(159357)</visible>
-        <texture>#fanarthandler.series.clearlogo.selected</texture>
+        <texture>#fanarthandler.tvseries.clearlogo.selected</texture>
         <animation effect="fade" time="250">WindowOpen</animation>
         <animation effect="fade" time="250">WindowClose</animation>
     </control>  

--- a/Common/Trakt.Show.Seasons.xml
+++ b/Common/Trakt.Show.Seasons.xml
@@ -28,7 +28,7 @@
         <posY>150</posY>
         <width>250</width>
         <height>140</height>
-        <texture>..\..\..\Thumbs\ClearArt\Series\#(string.trim(#Trakt.Show.TvdbId)).png</texture>
+        <texture>#fanarthandler.series.clearart.selected</texture>
         <animation effect="fade" time="250">WindowOpen</animation>
         <animation effect="fade" time="250">WindowClose</animation>
     </control>  
@@ -43,7 +43,7 @@
         <width>250</width>
         <height>140</height>
         <visible>!control.hasthumb(159357)</visible>
-        <texture>..\..\..\Thumbs\ClearLogo\Series\#(string.trim(#Trakt.Show.TvdbId)).png</texture>
+        <texture>#fanarthandler.series.clearlogo.selected</texture>
         <animation effect="fade" time="250">WindowOpen</animation>
         <animation effect="fade" time="250">WindowClose</animation>
     </control>  
@@ -128,7 +128,7 @@
       <posY>34</posY>
       <width>61</width>
       <height>60</height>
-      <texture>icon_plugin.png</texture>
+      <texture>icon_series.png</texture>
       <animation effect="fade" time="250">WindowOpen</animation>
       <animation effect="fade" time="250">WindowClose</animation>
     </control>

--- a/Common/Trakt.Trending.Movies.xml
+++ b/Common/Trakt.Trending.Movies.xml
@@ -1,0 +1,509 @@
+<?xml version="1.0" encoding="utf-8" standalone="yes"?>
+<window>
+  <id>87266</id>
+  <defaultcontrol>50</defaultcontrol>
+  <allowoverlay>no</allowoverlay>
+  <define>#Fanart.1:#Trakt.TrendingMovies.Fanart.1</define>
+  <define>#Fanart.2:#Trakt.TrendingMovies.Fanart.2</define>
+  <define>#header.label:#Trakt.Translation.TrendingMovies.Label</define>
+  <controls>
+  <!-- #fanarthandler.movie.genres.selected -->
+    <control>
+      <description>DEFAULT BACKGROUND</description>
+      <type>image</type>
+      <id>0</id>
+      <posX>0</posX>
+      <posY>0</posY>
+      <width>1920</width>
+      <height>1080</height>
+      <texture>background.png</texture>
+      <shouldCache>true</shouldCache>
+    </control>
+    <import>Trakt.Common.Fanart.xml</import>
+    <!--            :: BACKGROUNDS ::           	 -->
+    <control>
+      <description>background listview</description>
+      <type>image</type>
+      <id>0</id>
+      <posX>0</posX>
+      <posY>0</posY>
+      <width>1920</width>
+      <height>1080</height>
+      <texture>fanart_overlay.png</texture>
+      <visible>!Control.IsVisible(51)</visible>
+      <animation effect="fade" time="250">WindowOpen</animation>
+      <animation effect="fade" time="250">WindowClose</animation>
+    </control>
+    <control>
+      <description>background listview</description>
+      <type>image</type>
+      <id>0</id>
+      <posX>10</posX>
+      <posY>252</posY>
+      <width>1903</width>
+      <height>790</height>
+      <texture>panel_list.png</texture>
+      <visible>facadeview.list + Control.IsVisible(50)</visible>
+      <animation effect="fade" time="250">WindowOpen</animation>
+      <animation effect="fade" time="250">WindowClose</animation>
+    </control>
+    <control>
+      <description>background thumbs</description>
+      <type>image</type>
+      <id>0</id>
+      <posX>10</posX>
+      <posY>252</posY>
+      <width>1903</width>
+      <height>790</height>
+      <texture>panel_tvseries_widebanner.6x2.png</texture>
+      <visible>[facadeview.smallicons | facadeview.largeicons] + Control.IsVisible(50)</visible>
+      <animation effect="fade" time="250">WindowOpen</animation>
+      <animation effect="fade" time="250">WindowClose</animation>
+    </control>
+    <control>
+      <description>filmstrip overlay</description>
+      <type>image</type>
+      <id>0</id>
+      <posX>0</posX>
+      <posY>279</posY>
+      <width>1920</width>
+      <height>801</height>
+      <texture>filmstrip_overlay.png</texture>
+      <visible>[facadeview.filmstrip | facadeview.coverflow] + Control.IsVisible(50)</visible>
+      <animation effect="fade" time="250">WindowOpen</animation>
+      <animation effect="fade" time="250">WindowClose</animation>
+    </control>
+    <control>
+      <description>filmstrip overlay</description>
+      <type>image</type>
+      <id>0</id>
+      <posX>52</posX>
+      <posY>958</posY>
+      <width>1820</width>
+      <height>84</height>
+      <texture>BasicHomeSubBG.png</texture>
+      <visible>[facadeview.filmstrip | facadeview.coverflow] + Control.IsVisible(50)</visible>
+      <animation effect="fade" time="250">WindowOpen</animation>
+      <animation effect="fade" time="250">WindowClose</animation>
+    </control>
+    <control>
+      <id>0</id>
+      <type>image</type>
+      <posX>66</posX>
+      <posY>34</posY>
+      <width>61</width>
+      <height>60</height>
+      <texture>icon_movies.png</texture>
+      <animation effect="fade" time="250">WindowOpen</animation>
+      <animation effect="fade" time="250">WindowClose</animation>
+    </control>
+    <import>common.time.xml</import>
+    <control>
+      <description>Watchers</description>
+      <type>label</type>
+      <label>#Trakt.Trending.Description</label>
+      <id>0</id>
+      <posX>144</posX>
+      <posY>94</posY>
+      <width>1100</width>
+      <align>left</align>
+      <textcolor>FFFFFFFF</textcolor>
+      <font>TitanLight12</font>
+      <animation effect="fade" time="250">WindowOpen</animation>
+      <animation effect="fade" time="250">WindowClose</animation>
+    </control>
+
+    <!--            :: Count ::            -->
+    <control>
+      <description>Moviecount</description>
+      <type>label</type>
+      <label>#Trakt.Translation.Movies.Label: #itemcount</label>
+      <id>0</id>
+      <posX>96</posX>
+      <posY>998</posY>
+      <align>left</align>
+      <font>TitanLight12</font>
+      <textcolor>000000</textcolor>
+      <visible>[facadeview.list | facadeview.smallicons | facadeview.largeicons | facadeview.filmstrip | facadeview.coverflow] + control.isvisible(50)</visible>
+      <animation effect="fade" time="250">WindowOpen</animation>
+      <animation effect="fade" time="250">WindowClose</animation>
+    </control>
+    <!--            :: Listview Lines ::            -->
+    <control>
+      <description>List Lines</description>
+      <type>image</type>
+      <id>1</id>
+      <posX>1222</posX>
+      <posY>385</posY>
+      <width>607</width>
+      <height>506</height>
+      <texture>list_lines.png</texture>
+      <visible>facadeview.list + control.isvisible(50)</visible>
+      <animation effect="fade" time="250">WindowOpen</animation>
+      <animation effect="fade" time="250">WindowClose</animation>
+    </control>
+    <control>
+      <description>group element</description>
+      <type>group</type>
+      <animation effect="fade" time="250">WindowOpen</animation>
+      <animation effect="fade" time="250">WindowClose</animation>
+      <control>
+        <type>facadeview</type>
+        <id>50</id>
+        <control>
+          <description>Movie List</description>
+          <type>listcontrol</type>
+          <id>50</id>
+          <onleft>2</onleft>
+          <onright>2</onright>
+          <scrollOffset>1</scrollOffset>
+          <posX>1165</posX>
+          <posY>331</posY>
+          <height>700</height>
+          <width>698</width>
+          <textXOff>44</textXOff>
+          <textXOff2>650</textXOff2>
+          <textureHeight>54</textureHeight>
+          <textureFocus>listcontrol_item_selected.png</textureFocus>
+          <textureNoFocus>-</textureNoFocus>
+          <dimColor>ffffffff</dimColor>
+          <spinPosX>1828</spinPosX>
+          <spinPosY>1000</spinPosY>
+        </control>
+        <control>
+          <description>Filmstrip view</description>
+          <type>filmstrip</type>
+          <dimColor>90ffffff</dimColor>
+          <id>50</id>
+          <scrollOffset>3</scrollOffset>
+          <folderPrefix></folderPrefix>
+          <folderSuffix></folderSuffix>
+          <posX>130</posX>
+          <posY>595</posY>
+          <width>1700</width>
+          <height>340</height>
+          <onup>2</onup>
+          <ondown>2</ondown>
+          <onleft>50</onleft>
+          <onright>50</onright>
+          <thumbWidth>230</thumbWidth>
+          <thumbHeight>327</thumbHeight>
+          <thumbPosX>0</thumbPosX>
+          <thumbPosY>0</thumbPosY>
+          <itemWidth>240</itemWidth>
+          <itemHeight>327</itemHeight>
+          <textureWidth>230</textureWidth>
+          <textureHeight>327</textureHeight>
+          <textYOff>-2000</textYOff>
+          <imageFolderFocus>-</imageFolderFocus>
+          <frame>-</frame>
+          <frameFocus>-</frameFocus>
+          <background>-</background>
+          <thumbs flipY="true" diffuse="Thumb_Mask_test.png" mask="filmstrip_mask.png"></thumbs>
+          <showFrame>yes</showFrame>
+          <showFolder>no</showFolder>
+          <showBackGround>no</showBackGround>
+          <showInfoImage>no</showInfoImage>
+          <scrollbarBackground>scrollbar_bg_hor.png</scrollbarBackground>
+          <scrollbarLeft>scrollbar_left_hor.png</scrollbarLeft>
+          <scrollbarRight>scrollbar_right_hor.png</scrollbarRight>
+          <scrollbarWidth>717</scrollbarWidth>
+          <scrollbarHeight>8</scrollbarHeight>
+          <scrollbarYOff>375</scrollbarYOff>
+          <keepaspectratio>no</keepaspectratio>
+          <thumbAnimation effect="zoom" acceleration="-2" start="100,100" reversible="false" end="120,120" center="0,880" time="200">focus</thumbAnimation>
+          <thumbAnimation effect="zoom" start="120,120" reversible="false" end="100,100" center="0,880" time="100">unfocus</thumbAnimation>
+        </control>
+        <control>
+          <description>Thumbnail Panel</description>
+          <type>thumbnailpanel</type>
+          <id>50</id>
+          <posX>754</posX>
+          <posY>342</posY>
+          <width>1150</width>
+          <height>700</height>
+          <folderPrefix></folderPrefix>
+          <folderSuffix></folderSuffix>
+          <onleft>2</onleft>
+          <onright>2</onright>
+          <itemWidth>138</itemWidth>
+          <itemHeight>196</itemHeight>
+          <textureWidth>138</textureWidth>
+          <textureHeight>196</textureHeight>
+          <thumbWidth>128</thumbWidth>
+          <thumbHeight>186</thumbHeight>
+          <thumbPosX>6</thumbPosX>
+          <thumbPosY>5</thumbPosY>
+          <itemWidthBig>214</itemWidthBig>
+          <itemHeightBig>304</itemHeightBig>
+          <thumbWidthBig>204</thumbWidthBig>
+          <thumbHeightBig>294</thumbHeightBig>
+          <textureWidthBig>216</textureWidthBig>
+          <textureHeightBig>304</textureHeightBig>
+          <thumbPosXBig>6</thumbPosXBig>
+          <thumbPosYBig>5</thumbPosYBig>
+          <zoomXPixels>0</zoomXPixels>
+          <zoomYPixels>0</zoomYPixels>
+          <hideUnfocusTexture>no</hideUnfocusTexture>
+          <keepaspectratio>no</keepaspectratio>
+          <renderFocusText>no</renderFocusText>
+          <renderUnfocusText>no</renderUnfocusText>
+          <frameNoFocus>-</frameNoFocus>
+          <frameFocus>video_thumb_focus.png</frameFocus>
+          <textureMask></textureMask>
+          <shadowAngle>90</shadowAngle>
+          <shadowDistance>50</shadowDistance>
+          <thumbZoom>no</thumbZoom>
+          <spinPosX>1828</spinPosX>
+          <spinPosY>1000</spinPosY>
+          <unfocusedAlpha>100</unfocusedAlpha>
+        </control>
+        <control>
+          <description>Cover Flow view</description>
+          <type>coverflow</type>
+          <colordiffuse>90ffffff</colordiffuse>
+          <dimColor>90ffffff</dimColor>
+          <id>50</id>
+          <onup>2</onup>
+          <ondown>2</ondown>
+          <onleft>50</onleft>
+          <onright>50</onright>
+          <posX>0</posX>
+          <posY>595</posY>
+          <width>1920</width>
+          <height>340</height>
+          <selectedCard>0</selectedCard>
+          <cardWidth>238</cardWidth>
+          <cardHeight>340</cardHeight>
+          <angle>55</angle>
+          <sideShift>150</sideShift>
+          <sideGap>120</sideGap>
+          <sideDepth>110</sideDepth>
+          <offsetY>0</offsetY>
+          <selectedOffsetY>0</selectedOffsetY>
+          <speed>10</speed>
+          <showFrame>yes</showFrame>
+          <frame>-</frame>
+          <frameFocus>-</frameFocus>
+          <keepaspectratio>no</keepaspectratio>
+          <frameWidth>238</frameWidth>
+          <frameHeight>340</frameHeight>
+          <spinSpeed>8</spinSpeed>
+          <unfocusedAlpha>FF</unfocusedAlpha>
+          <folderPrefix></folderPrefix>
+          <folderSuffix></folderSuffix>
+          <font1>font13</font1>
+          <font2>font11</font2>
+          <label1>#title</label1>
+          <label2>#genre</label2>
+          <textColor>FFFFFFFF</textColor>
+          <remoteColor>FFFF0000</remoteColor>
+          <playedColor>FFA0D0FF</playedColor>
+          <downloadColor>FF00FF00</downloadColor>
+          <selectedColor>FFFFFFFF</selectedColor>
+          <shadowAngle>45</shadowAngle>
+          <shadowDistance>1</shadowDistance>
+          <shadowColor>FF000000</shadowColor>
+          <label1YOff>1430</label1YOff>
+          <label2YOff>1390</label2YOff>
+          <pageSize>5</pageSize>
+          <scrollbarBackground>scrollbar_bg_hor.png</scrollbarBackground>
+          <scrollbarLeft>scrollbar_left_hor.png</scrollbarLeft>
+          <scrollbarRight>scrollbar_right_hor.png</scrollbarRight>
+          <scrollbarWidth>717</scrollbarWidth>
+          <scrollbarHeight>8</scrollbarHeight>
+          <scrollbarYOff>375</scrollbarYOff>
+          <cards flipY="true" diffuse="Thumb_Mask_test.png" mask="filmstrip_mask.png"></cards>
+        </control>
+      </control>
+    </control>
+    <!--            :: HIDDEN MENU ::           	 -->
+    <control>
+      <id>1</id>
+      <type>image</type>
+      <posX>0</posX>
+      <posY>440</posY>
+      <width>64</width>
+      <height>199</height>
+      <texture>hiddenmenu_tab.png</texture>
+      <visible>[facadeview.list | facadeview.smallicons | facadeview.largeicons]+Control.HasFocus(50) + !string.contains(#Titan.HiddenMenu, false)</visible>
+      <animation effect="slide" start="-60,0" end="0,0" tween="quadratic" easing="in" time="250" delay="400">WindowOpen</animation>
+      <animation effect="slide" start="0,0" end="-60,0" tween="quadratic" easing="in" time="250" delay="100">WindowClose</animation>
+    </control>
+    <control>
+      <id>1</id>
+      <type>image</type>
+      <posX>858</posX>
+      <posY>0</posY>
+      <texture>hiddenmenu_tab_up.png</texture>
+      <visible>[facadeview.filmstrip | facadeview.coverflow] + Control.HasFocus(50) + !string.contains(#Titan.HiddenMenu, false)</visible>
+      <animation effect="slide" start="0,-60" end="0,0" tween="quadratic" easing="in" time="250" delay="400">WindowOpen</animation>
+      <animation effect="slide" start="0,0" end="0,-60" tween="quadratic" easing="in" time="250" delay="100">WindowClose</animation>
+    </control>
+    <control>
+      <type>actiongroup</type>
+      <description>action menu</description>
+      <defaultcontrol>3</defaultcontrol>
+      <onexit>50</onexit>
+      <dimColor>00ffffff</dimColor>
+      <buttonX>-460</buttonX>
+      <buttonY>155</buttonY>
+      <buttonwidth>499</buttonwidth>
+      <buttonheight>1080</buttonheight>
+      <control>
+        <type>image</type>
+        <id>0</id>
+        <width>1920</width>
+        <height>1080</height>
+        <texture>semi_trans_back_hidden_menu.png</texture>
+        <visible>!Control.HasFocus(50)+control.isvisible(50)</visible>
+        <animation effect="fade" time="450">visible</animation>
+        <animation effect="fade" time="400">hidden</animation>
+      </control>
+      <control>
+        <type>image</type>
+        <id>0</id>
+        <posY>0</posY>
+        <posX>0</posX>
+        <width>612</width>
+        <height>1074</height>
+        <texture>menu_bg.png</texture>
+        <visible>!Control.HasFocus(50)+control.isvisible(50)</visible>
+        <animation effect="fade" time="0">WindowClose</animation>
+        <animation effect="slide" start="-150,0" time="100">visible</animation>
+        <animation effect="fade" time="50">visible</animation>
+        <animation effect="fade" time="0">hidden</animation>
+      </control>
+      <control>
+        <description>Menu label</description>
+        <type>label</type>
+        <id>1</id>
+        <posX>116</posX>
+        <posY>100</posY>
+        <label>924</label>
+        <font>fontB16</font>
+        <textcolor>393939</textcolor>
+        <visible>!Control.HasFocus(50)+control.isvisible(50)</visible>
+        <animation effect="fade" time="0">WindowClose</animation>
+        <animation effect="slide" start="-150,0" time="100">visible</animation>
+        <animation effect="fade" time="50">visible</animation>
+        <animation effect="fade" time="0">hidden</animation>
+      </control>
+      <control>
+        <type>group</type>
+        <description>group element</description>
+        <visible>!Control.HasFocus(50)+control.isvisible(50)</visible>
+        <animation effect="fade" time="0">WindowClose</animation>
+        <animation effect="slide" start="-150,0" time="100">visible</animation>
+        <animation effect="fade" time="50">visible</animation>
+        <animation effect="fade" time="0">hidden</animation>
+        <posX>53</posX>
+        <posY>155</posY>
+        <layout>StackLayout(0, Vertical, true)</layout>
+        <control>
+          <description>Change Layout</description>
+          <type>button</type>
+          <id>2</id>
+          <textureFocus>hiddenmenu_item_selected.png</textureFocus>
+          <textureNoFocus>-</textureNoFocus>
+          <width>499</width>
+          <height>69</height>
+          <textXOff>62</textXOff>
+          <textYOff>16</textYOff>
+          <label>-</label>
+          <onright>50</onright>
+          <ondown>8</ondown>
+          <onup>8</onup>
+        </control>
+        <control>
+          <description>Sort</description>
+          <type>sortbutton</type>
+          <id>8</id>
+          <label>-</label>
+          <textureFocus>hiddenmenu_item_selected.png</textureFocus>
+          <textureNoFocus>-</textureNoFocus>
+          <width>499</width>
+          <height>69</height>
+          <textXOff>62</textXOff>
+          <textYOff>16</textYOff>
+          <offsetSortButtonX>421</offsetSortButtonX>
+          <offsetSortButtonY>27</offsetSortButtonY>
+          <onright>50</onright>
+          <onleft>50</onleft>
+          <ondown>9</ondown>
+          <onup>2</onup>
+        </control>
+        <control>
+          <description>Hide Watched</description>
+          <type>checkbutton</type>
+          <id>9</id>
+          <width>499</width>
+          <height>69</height>
+          <textureFocus>hiddenmenu_item_selected.png</textureFocus>
+          <textureNoFocus>-</textureNoFocus>
+          <textcolorNoFocus>ff393939</textcolorNoFocus>
+          <label>#Trakt.Translation.HideWatched.Label</label>
+          <onup>8</onup>
+          <ondown>10</ondown>
+          <onright>50</onright>
+          <onleft>50</onleft>
+          <textXOff>62</textXOff>
+          <textYOff>16</textYOff>
+        </control>
+        <control>
+          <description>Hide Watchlisted</description>
+          <type>checkbutton</type>
+          <id>10</id>
+          <width>499</width>
+          <height>69</height>
+          <textureFocus>hiddenmenu_item_selected.png</textureFocus>
+          <textureNoFocus>-</textureNoFocus>
+          <textcolorNoFocus>ff393939</textcolorNoFocus>
+          <label>#Trakt.Translation.HideWatchlisted.Label</label>
+          <onup>9</onup>
+          <ondown>11</ondown>
+          <onright>50</onright>
+          <onleft>50</onleft>
+          <textXOff>62</textXOff>
+          <textYOff>16</textYOff>
+        </control>
+        <control>
+          <description>Hide Collected</description>
+          <type>checkbutton</type>
+          <id>11</id>
+          <width>499</width>
+          <height>69</height>
+          <textureFocus>hiddenmenu_item_selected.png</textureFocus>
+          <textureNoFocus>-</textureNoFocus>
+          <textcolorNoFocus>ff393939</textcolorNoFocus>
+          <label>#Trakt.Translation.HideCollected.Label</label>
+          <onup>10</onup>
+          <ondown>12</ondown>
+          <onright>50</onright>
+          <onleft>50</onleft>
+          <textXOff>62</textXOff>
+          <textYOff>16</textYOff>
+        </control>
+        <control>
+          <description>Hide Rated</description>
+          <type>checkbutton</type>
+          <id>12</id>
+          <width>499</width>
+          <height>69</height>
+          <textureFocus>hiddenmenu_item_selected.png</textureFocus>
+          <textureNoFocus>-</textureNoFocus>
+          <textcolorNoFocus>ff393939</textcolorNoFocus>
+          <label>#Trakt.Translation.HideRated.Label</label>
+          <onup>11</onup>
+          <ondown>2</ondown>
+          <onright>50</onright>
+          <onleft>50</onleft>
+          <textXOff>62</textXOff>
+          <textYOff>16</textYOff>
+        </control>
+      </control>
+    </control>
+    <import>Trakt.Common.Movies.xml</import>
+    <import>common.overlay.xml</import>
+  </controls>
+</window>

--- a/Common/Trakt.Trending.Shows.xml
+++ b/Common/Trakt.Trending.Shows.xml
@@ -1,0 +1,524 @@
+<?xml version="1.0" encoding="utf-8" standalone="yes"?>
+<window>
+  <id>87265</id>
+  <defaultcontrol>50</defaultcontrol>
+  <allowoverlay>no</allowoverlay>
+  <define>#Fanart.1:#Trakt.TrendingShows.Fanart.1</define>
+  <define>#Fanart.2:#Trakt.TrendingShows.Fanart.2</define>
+  <define>#header.label:#Trakt.Translation.TrendingShows.Label</define>
+  <controls>
+
+    <control>
+      <description>DEFAULT BACKGROUND</description>
+      <type>image</type>
+      <id>0</id>
+      <posX>0</posX>
+      <posY>0</posY>
+      <width>1920</width>
+      <height>1080</height>
+      <texture>background.png</texture>
+      <shouldCache>true</shouldCache>
+    </control>
+
+    <import>Trakt.Common.Fanart.xml</import>
+
+    <!--            :: BACKGROUNDS ::           	 -->
+
+    <control>
+      <description>background listview</description>
+      <type>image</type>
+      <id>0</id>
+      <posX>0</posX>
+      <posY>0</posY>
+      <width>1920</width>
+      <height>1080</height>
+      <texture>fanart_overlay.png</texture>
+      <visible>[facadeview.list | facadeview.smallicons | facadeview.largeicons | facadeview.filmstrip | facadeview.coverflow] + Control.IsVisible(50)</visible>
+      <animation effect="fade" time="250">WindowOpen</animation>
+      <animation effect="fade" time="250">WindowClose</animation>
+    </control>
+
+    <control>
+      <description>background listview</description>
+      <type>image</type>
+      <id>0</id>
+      <posX>10</posX>
+      <posY>252</posY>
+      <width>1903</width>
+      <height>790</height>
+      <texture>panel_list.png</texture>
+      <visible>facadeview.list + Control.IsVisible(50)</visible>
+      <animation effect="fade" time="250">WindowOpen</animation>
+      <animation effect="fade" time="250">WindowClose</animation>
+    </control>
+
+    <control>
+      <description>background thumbs</description>
+      <type>image</type>
+      <id>0</id>
+      <posX>10</posX>
+      <posY>252</posY>
+      <width>1903</width>
+      <height>790</height>
+      <texture>panel_tvseries_widebanner.6x2.png</texture>
+      <visible>[facadeview.smallicons | facadeview.largeicons] + Control.IsVisible(50)</visible>
+      <animation effect="fade" time="250">WindowOpen</animation>
+      <animation effect="fade" time="250">WindowClose</animation>
+    </control>
+
+    <control>
+      <description>filmstrip overlay</description>
+      <type>image</type>
+      <id>0</id>
+      <posX>10</posX>
+      <posY>490</posY>
+      <width>1903</width>
+      <height>552</height>
+      <texture>panel_filmstrip.png</texture>
+      <visible>[facadeview.filmstrip | facadeview.coverflow] + Control.IsVisible(50)</visible>
+      <animation effect="fade" time="250">WindowOpen</animation>
+      <animation effect="fade" time="250">WindowClose</animation>
+    </control>
+
+    <control>
+      <id>0</id>
+      <type>image</type>
+      <posX>66</posX>
+      <posY>34</posY>
+      <width>61</width>
+      <height>60</height>
+      <texture>icon_series.png</texture>
+      <animation effect="fade" time="250">WindowOpen</animation>
+      <animation effect="fade" time="250">WindowClose</animation>
+    </control>
+
+    <import>common.time.xml</import>
+    <control>
+      <description>Watchers</description>
+      <type>label</type>
+      <label>#Trakt.Trending.Description</label>
+      <id>0</id>
+      <posX>144</posX>
+      <posY>94</posY>
+      <width>1100</width>
+      <align>left</align>
+      <textcolor>FFFFFFFF</textcolor>
+      <font>TitanLight12</font>
+      <animation effect="fade" time="250">WindowOpen</animation>
+      <animation effect="fade" time="250">WindowClose</animation>
+    </control>
+
+    <!--            :: Count ::            -->
+
+    <control>
+      <description>Show Count</description>
+      <type>label</type>
+      <label>#Trakt.Translation.Series.Label: #itemcount</label>
+      <id>0</id>
+      <posX>96</posX>
+      <posY>998</posY>
+      <align>left</align>
+      <font>TitanLight12</font>
+      <textcolor>000000</textcolor>
+      <visible>[facadeview.list | facadeview.smallicons | facadeview.largeicons | facadeview.filmstrip | facadeview.coverflow] + control.isvisible(50)</visible>
+      <animation effect="fade" time="250">WindowOpen</animation>
+      <animation effect="fade" time="250">WindowClose</animation>
+    </control>
+
+    <!--            :: Listview Lines ::            -->
+
+    <control>
+      <description>List Lines</description>
+      <type>image</type>
+      <id>1</id>
+      <posX>1222</posX>
+      <posY>385</posY>
+      <width>607</width>
+      <height>506</height>
+      <texture>list_lines.png</texture>
+      <visible>facadeview.list + control.isvisible(50)</visible>
+      <animation effect="fade" time="250">WindowOpen</animation>
+      <animation effect="fade" time="250">WindowClose</animation>
+    </control>
+
+    <control>
+      <description>group element</description>
+      <type>group</type>
+      <animation effect="fade" time="250">WindowOpen</animation>
+      <animation effect="fade" time="250">WindowClose</animation>
+      <control>
+        <type>facadeview</type>
+        <id>50</id>
+        <control>
+          <description>Movie List</description>
+          <type>listcontrol</type>
+          <id>50</id>
+          <onleft>2</onleft>
+          <onright>2</onright>
+          <scrollOffset>1</scrollOffset>
+          <posX>1165</posX>
+          <posY>331</posY>
+          <height>700</height>
+          <width>698</width>
+          <textXOff>44</textXOff>
+          <textXOff2>650</textXOff2>
+          <textureHeight>54</textureHeight>
+          <textureFocus>listcontrol_item_selected.png</textureFocus>
+          <textureNoFocus>-</textureNoFocus>
+          <dimColor>ffffffff</dimColor>
+          <spinPosX>1828</spinPosX>
+          <spinPosY>1000</spinPosY>
+        </control>
+
+        <control>
+          <description>Filmstrip view</description>
+          <type>filmstrip</type>
+          <dimColor>90ffffff</dimColor>
+          <id>50</id>
+          <scrollOffset>3</scrollOffset>
+          <folderPrefix></folderPrefix>
+          <folderSuffix></folderSuffix>
+          <posX>130</posX>
+          <posY>595</posY>
+          <width>1700</width>
+          <height>340</height>
+          <onup>2</onup>
+          <ondown>2</ondown>
+          <onleft>50</onleft>
+          <onright>50</onright>
+          <thumbWidth>230</thumbWidth>
+          <thumbHeight>327</thumbHeight>
+          <thumbPosX>0</thumbPosX>
+          <thumbPosY>0</thumbPosY>
+          <itemWidth>240</itemWidth>
+          <itemHeight>327</itemHeight>
+          <textureWidth>230</textureWidth>
+          <textureHeight>327</textureHeight>
+          <textYOff>-2000</textYOff>
+          <imageFolderFocus>-</imageFolderFocus>
+          <frame>-</frame>
+          <frameFocus>-</frameFocus>
+          <background>-</background>
+          <thumbs flipY="true" diffuse="Thumb_Mask_test.png" mask="filmstrip_mask.png"></thumbs>
+          <showFrame>yes</showFrame>
+          <showFolder>no</showFolder>
+          <showBackGround>no</showBackGround>
+          <showInfoImage>no</showInfoImage>
+          <scrollbarBackground>scrollbar_bg_hor.png</scrollbarBackground>
+          <scrollbarLeft>scrollbar_left_hor.png</scrollbarLeft>
+          <scrollbarRight>scrollbar_right_hor.png</scrollbarRight>
+          <scrollbarWidth>717</scrollbarWidth>
+          <scrollbarHeight>8</scrollbarHeight>
+          <scrollbarYOff>375</scrollbarYOff>
+          <keepaspectratio>no</keepaspectratio>
+          <thumbAnimation effect="zoom" acceleration="-2" start="100,100" reversible="false" end="120,120" center="0,880" time="200">focus</thumbAnimation>
+          <thumbAnimation effect="zoom" start="120,120" reversible="false" end="100,100" center="0,880" time="100">unfocus</thumbAnimation>
+        </control>
+
+        <control>
+          <description>Thumbnail Panel</description>
+          <type>thumbnailpanel</type>
+          <id>50</id>
+          <posX>754</posX>
+          <posY>342</posY>
+          <width>1150</width>
+          <height>700</height>
+          <folderPrefix></folderPrefix>
+          <folderSuffix></folderSuffix>
+          <onleft>2</onleft>
+          <onright>2</onright>
+          <itemWidth>138</itemWidth>
+          <itemHeight>196</itemHeight>
+          <textureWidth>138</textureWidth>
+          <textureHeight>196</textureHeight>
+          <thumbWidth>128</thumbWidth>
+          <thumbHeight>186</thumbHeight>
+          <thumbPosX>6</thumbPosX>
+          <thumbPosY>5</thumbPosY>
+          <itemWidthBig>214</itemWidthBig>
+          <itemHeightBig>304</itemHeightBig>
+          <thumbWidthBig>204</thumbWidthBig>
+          <thumbHeightBig>294</thumbHeightBig>
+          <textureWidthBig>216</textureWidthBig>
+          <textureHeightBig>304</textureHeightBig>
+          <thumbPosXBig>6</thumbPosXBig>
+          <thumbPosYBig>5</thumbPosYBig>
+          <zoomXPixels>0</zoomXPixels>
+          <zoomYPixels>0</zoomYPixels>
+          <hideUnfocusTexture>no</hideUnfocusTexture>
+          <keepaspectratio>no</keepaspectratio>
+          <renderFocusText>no</renderFocusText>
+          <renderUnfocusText>no</renderUnfocusText>
+          <frameNoFocus>-</frameNoFocus>
+          <frameFocus>video_thumb_focus.png</frameFocus>
+          <textureMask></textureMask>
+          <shadowAngle>90</shadowAngle>
+          <shadowDistance>50</shadowDistance>
+          <thumbZoom>no</thumbZoom>
+          <spinPosX>1828</spinPosX>
+          <spinPosY>1000</spinPosY>
+          <unfocusedAlpha>100</unfocusedAlpha>
+        </control>
+
+        <control>
+          <description>Cover Flow view</description>
+          <type>coverflow</type>
+          <colordiffuse>90ffffff</colordiffuse>
+          <dimColor>90ffffff</dimColor>
+          <id>50</id>
+          <onup>2</onup>
+          <ondown>2</ondown>
+          <onleft>50</onleft>
+          <onright>50</onright>
+          <posX>0</posX>
+          <posY>595</posY>
+          <width>1920</width>
+          <height>340</height>
+          <selectedCard>0</selectedCard>
+          <cardWidth>238</cardWidth>
+          <cardHeight>340</cardHeight>
+          <angle>55</angle>
+          <sideShift>150</sideShift>
+          <sideGap>120</sideGap>
+          <sideDepth>110</sideDepth>
+          <offsetY>0</offsetY>
+          <selectedOffsetY>0</selectedOffsetY>
+          <speed>10</speed>
+          <showFrame>yes</showFrame>
+          <frame>-</frame>
+          <frameFocus>-</frameFocus>
+          <keepaspectratio>no</keepaspectratio>
+          <frameWidth>238</frameWidth>
+          <frameHeight>340</frameHeight>
+          <spinSpeed>8</spinSpeed>
+          <unfocusedAlpha>FF</unfocusedAlpha>
+          <folderPrefix></folderPrefix>
+          <folderSuffix></folderSuffix>
+          <font1>font13</font1>
+          <font2>font11</font2>
+          <label1>#title</label1>
+          <label2>#genre</label2>
+          <textColor>FFFFFFFF</textColor>
+          <remoteColor>FFFF0000</remoteColor>
+          <playedColor>FFA0D0FF</playedColor>
+          <downloadColor>FF00FF00</downloadColor>
+          <selectedColor>FFFFFFFF</selectedColor>
+          <shadowAngle>45</shadowAngle>
+          <shadowDistance>1</shadowDistance>
+          <shadowColor>FF000000</shadowColor>
+          <label1YOff>1430</label1YOff>
+          <label2YOff>1390</label2YOff>
+          <pageSize>5</pageSize>
+          <scrollbarBackground>scrollbar_bg_hor.png</scrollbarBackground>
+          <scrollbarLeft>scrollbar_left_hor.png</scrollbarLeft>
+          <scrollbarRight>scrollbar_right_hor.png</scrollbarRight>
+          <scrollbarWidth>717</scrollbarWidth>
+          <scrollbarHeight>8</scrollbarHeight>
+          <scrollbarYOff>375</scrollbarYOff>
+          <cards flipY="true" diffuse="Thumb_Mask_test.png" mask="filmstrip_mask.png"></cards>
+        </control>
+      </control>
+    </control>
+
+    <!--            :: HIDDEN MENU ::           	 -->
+
+    <control>
+      <id>1</id>
+      <type>image</type>
+      <posX>0</posX>
+      <posY>440</posY>
+      <width>64</width>
+      <height>199</height>
+      <texture>hiddenmenu_tab.png</texture>
+      <visible>[facadeview.list | facadeview.smallicons | facadeview.largeicons]+Control.HasFocus(50) + !string.contains(#Titan.HiddenMenu, false)</visible>
+      <animation effect="slide" start="-60,0" end="0,0" tween="quadratic" easing="in" time="250" delay="400">WindowOpen</animation>
+      <animation effect="slide" start="0,0" end="-60,0" tween="quadratic" easing="in" time="250" delay="100">WindowClose</animation>
+    </control>
+
+    <control>
+      <id>1</id>
+      <type>image</type>
+      <posX>858</posX>
+      <posY>0</posY>
+      <texture>hiddenmenu_tab_up.png</texture>
+      <visible>[facadeview.filmstrip | facadeview.coverflow] + Control.HasFocus(50) + !string.contains(#Titan.HiddenMenu, false)</visible>
+      <animation effect="slide" start="0,-60" end="0,0" tween="quadratic" easing="in" time="250" delay="400">WindowOpen</animation>
+      <animation effect="slide" start="0,0" end="0,-60" tween="quadratic" easing="in" time="250" delay="100">WindowClose</animation>
+    </control>
+
+    <control>
+      <type>actiongroup</type>
+      <description>action menu</description>
+      <defaultcontrol>3</defaultcontrol>
+      <onexit>50</onexit>
+      <dimColor>00ffffff</dimColor>
+      <buttonX>-460</buttonX>
+      <buttonY>155</buttonY>
+      <buttonwidth>499</buttonwidth>
+      <buttonheight>1080</buttonheight>
+
+      <control>
+        <type>image</type>
+        <id>0</id>
+        <width>1920</width>
+        <height>1080</height>
+        <texture>semi_trans_back_hidden_menu.png</texture>
+        <visible>!Control.HasFocus(50)+control.isvisible(50)</visible>
+        <animation effect="fade" time="450">visible</animation>
+        <animation effect="fade" time="400">hidden</animation>
+      </control>
+
+      <control>
+        <type>image</type>
+        <id>0</id>
+        <posY>0</posY>
+        <posX>0</posX>
+        <width>612</width>
+        <height>1074</height>
+        <texture>menu_bg.png</texture>
+        <visible>!Control.HasFocus(50)+control.isvisible(50)</visible>
+        <animation effect="fade" time="0">WindowClose</animation>
+        <animation effect="slide" start="-150,0" time="100">visible</animation>
+        <animation effect="fade" time="50">visible</animation>
+        <animation effect="fade" time="0">hidden</animation>
+      </control>
+      <control>
+        <description>Menu label</description>
+        <type>label</type>
+        <id>1</id>
+        <posX>116</posX>
+        <posY>100</posY>
+        <label>924</label>
+        <font>fontB16</font>
+        <textcolor>393939</textcolor>
+        <visible>!Control.HasFocus(50)+control.isvisible(50)</visible>
+        <animation effect="fade" time="0">WindowClose</animation>
+        <animation effect="slide" start="-150,0" time="100">visible</animation>
+        <animation effect="fade" time="50">visible</animation>
+        <animation effect="fade" time="0">hidden</animation>
+      </control>
+      <control>
+        <type>group</type>
+        <description>group element</description>
+        <visible>!Control.HasFocus(50)+control.isvisible(50)</visible>
+        <animation effect="fade" time="0">WindowClose</animation>
+        <animation effect="slide" start="-150,0" time="100">visible</animation>
+        <animation effect="fade" time="50">visible</animation>
+        <animation effect="fade" time="0">hidden</animation>
+        <posX>53</posX>
+        <posY>155</posY>
+        <layout>StackLayout(0, Vertical, true)</layout>
+
+        <control>
+          <description>Change Layout</description>
+          <type>button</type>
+          <id>2</id>
+          <textureFocus>hiddenmenu_item_selected.png</textureFocus>
+          <textureNoFocus>-</textureNoFocus>
+          <width>499</width>
+          <height>69</height>
+          <textXOff>62</textXOff>
+          <textYOff>16</textYOff>
+          <label>-</label>
+          <onright>50</onright>
+          <ondown>8</ondown>
+          <onup>8</onup>
+        </control>
+
+        <control>
+          <description>Sort</description>
+          <type>sortbutton</type>
+          <id>8</id>
+          <label>-</label>
+          <textureFocus>hiddenmenu_item_selected.png</textureFocus>
+          <textureNoFocus>-</textureNoFocus>
+          <width>499</width>
+          <height>69</height>
+          <textXOff>62</textXOff>
+          <textYOff>16</textYOff>
+          <offsetSortButtonX>421</offsetSortButtonX>
+          <offsetSortButtonY>27</offsetSortButtonY>
+          <onright>50</onright>
+          <onleft>50</onleft>
+          <ondown>9</ondown>
+          <onup>2</onup>
+        </control>
+
+        <control>
+          <description>Hide Watched</description>
+          <type>checkbutton</type>
+          <id>9</id>
+          <width>499</width>
+          <height>69</height>
+          <textureFocus>hiddenmenu_item_selected.png</textureFocus>
+          <textureNoFocus>-</textureNoFocus>
+          <label>#Trakt.Translation.HideWatched.Label</label>
+          <textcolorNoFocus>ff393939</textcolorNoFocus>
+          <onup>8</onup>
+          <ondown>10</ondown>
+          <onright>50</onright>
+          <onleft>50</onleft>
+          <textXOff>62</textXOff>
+          <textYOff>16</textYOff>
+        </control>
+
+        <control>
+          <description>Hide Watchlisted</description>
+          <type>checkbutton</type>
+          <id>10</id>
+          <width>499</width>
+          <height>69</height>
+          <textureFocus>hiddenmenu_item_selected.png</textureFocus>
+          <textureNoFocus>-</textureNoFocus>
+          <label>#Trakt.Translation.HideWatchlisted.Label</label>
+          <textcolorNoFocus>ff393939</textcolorNoFocus>
+          <onup>9</onup>
+          <ondown>11</ondown>
+          <onright>50</onright>
+          <onleft>50</onleft>
+          <textXOff>62</textXOff>
+          <textYOff>16</textYOff>
+        </control>
+
+        <control>
+          <description>Hide Collected</description>
+          <type>checkbutton</type>
+          <id>11</id>
+          <width>499</width>
+          <height>69</height>
+          <textureFocus>hiddenmenu_item_selected.png</textureFocus>
+          <textureNoFocus>-</textureNoFocus>
+          <label>#Trakt.Translation.HideCollected.Label</label>
+          <textcolorNoFocus>ff393939</textcolorNoFocus>
+          <onup>10</onup>
+          <ondown>12</ondown>
+          <onright>50</onright>
+          <onleft>50</onleft>
+          <textXOff>62</textXOff>
+          <textYOff>16</textYOff>
+        </control>
+
+        <control>
+          <description>Hide Rated</description>
+          <type>checkbutton</type>
+          <id>12</id>
+          <width>499</width>
+          <height>69</height>
+          <textureFocus>hiddenmenu_item_selected.png</textureFocus>
+          <textureNoFocus>-</textureNoFocus>
+          <textcolorNoFocus>ff393939</textcolorNoFocus>
+          <label>#Trakt.Translation.HideRated.Label</label>
+          <onup>11</onup>
+          <ondown>2</ondown>
+          <onright>50</onright>
+          <onleft>50</onleft>
+          <textXOff>62</textXOff>
+          <textYOff>16</textYOff>
+        </control>
+
+      </control>
+    </control>
+    <import>Trakt.Common.Shows.xml</import>
+    <import>common.overlay.xml</import>
+  </controls>
+</window>

--- a/Common/Trakt.xml
+++ b/Common/Trakt.xml
@@ -154,7 +154,7 @@
       <width>275</width>
       <height>140</height>
       <keepaspectratio>yes</keepaspectratio>
-      <texture>..\..\..\Thumbs\ClearArt\Series\#(string.trim(#Trakt.Show.TvdbId)).png</texture>
+      <texture>#fanarthandler.series.clearart.selected</texture>
       <visible>control.hasfocus(98301)+control.hasthumb(101)</visible>
       <animation effect="fade" time="250">WindowOpen</animation>
       <animation effect="fade" time="250">WindowClose</animation>
@@ -186,7 +186,7 @@
       <width>275</width>
       <height>140</height>
       <keepaspectratio>yes</keepaspectratio>
-      <texture>..\..\..\Thumbs\ClearArt\Series\#(string.trim(#Trakt.Show.TvdbId)).png</texture>
+      <texture>#fanarthandler.series.clearart.selected</texture>
       <visible>control.hasfocus(98300)+control.hasthumb(300)</visible>
       <animation effect="fade" time="250">WindowOpen</animation>
       <animation effect="fade" time="250">WindowClose</animation>

--- a/Common/Trakt.xml
+++ b/Common/Trakt.xml
@@ -170,7 +170,7 @@
       <width>275</width>
       <height>140</height>
       <keepaspectratio>yes</keepaspectratio>
-      <texture>..\..\..\Thumbs\ClearArt\Movies\#(string.trim(#Trakt.Movie.ImdbId)).png</texture>
+      <texture>#fanarthandler.movie.clearart.selected</texture>
       <visible>control.hasfocus(98302)+control.hasthumb(202)</visible>
       <animation effect="fade" time="250">WindowOpen</animation>
       <animation effect="fade" time="250">WindowClose</animation>
@@ -202,7 +202,7 @@
       <width>275</width>
       <height>140</height>
       <keepaspectratio>yes</keepaspectratio>
-      <texture>..\..\..\Thumbs\ClearArt\Movies\#(string.trim(#Trakt.Movie.ImdbId)).png</texture>
+      <texture>#fanarthandler.movie.clearart.selected</texture>
       <visible>control.hasfocus(98300)+control.hasthumb(301)</visible>
       <animation effect="fade" time="250">WindowOpen</animation>
       <animation effect="fade" time="250">WindowClose</animation>

--- a/Common/Trakt.xml
+++ b/Common/Trakt.xml
@@ -154,7 +154,7 @@
       <width>275</width>
       <height>140</height>
       <keepaspectratio>yes</keepaspectratio>
-      <texture>#fanarthandler.series.clearart.selected</texture>
+      <texture>#fanarthandler.tvseries.clearart.selected</texture>
       <visible>control.hasfocus(98301)+control.hasthumb(101)</visible>
       <animation effect="fade" time="250">WindowOpen</animation>
       <animation effect="fade" time="250">WindowClose</animation>
@@ -186,7 +186,7 @@
       <width>275</width>
       <height>140</height>
       <keepaspectratio>yes</keepaspectratio>
-      <texture>#fanarthandler.series.clearart.selected</texture>
+      <texture>#fanarthandler.tvseries.clearart.selected</texture>
       <visible>control.hasfocus(98300)+control.hasthumb(300)</visible>
       <animation effect="fade" time="250">WindowOpen</animation>
       <animation effect="fade" time="250">WindowClose</animation>


### PR DESCRIPTION
Trakt.Common.Movies.xml and Trakt.Popular.Movies.xml modified to use FanartHandler paths.

Trakt Movie xml files added to add FanartHandler hack to enable Clearart.
This is the tag that gets read in the xml files: <!-- #fanarthandler.movie.genres.selected -->
Changed plugin icon to movie icon.

This requires FanartHandler update to work.