### PR TITLE
Updated ClearArt paths and Aspect Ration logo Xpos for resized logos

### DIFF
--- a/Common/DialogPinCode.xml
+++ b/Common/DialogPinCode.xml
@@ -1,0 +1,134 @@
+<?xml version="1.0" encoding="utf-8" standalone="yes"?>
+<window>
+  <id>9915</id>
+  <defaultcontrol>10</defaultcontrol>
+  <allowoverlay>yes</allowoverlay>
+  <controls>
+		<import>common.dialog.xml</import>
+    <control>
+      <id>1</id>
+      <description>PinCode Item 1</description>
+      <type>image</type>
+      <onup>101</onup>
+      <posX>850</posX>
+      <posY>766</posY>
+      <width>53</width>
+      <height>41</height>
+      <texture>starblack_rating.png</texture>
+    	<animation effect="fade" time="250">WindowOpen</animation>
+    	<animation effect="slide" start="0,150" end="0,0" tween="quadratic" easing="in" time="200" delay="0">WindowOpen</animation>
+    	<animation effect="fade" time="0">WindowClose</animation>
+    </control>
+    <control>
+      <id>100</id>
+      <description>PinCode Item 1</description>
+      <type>image</type>
+      <onup>101</onup>
+      <posX>850</posX>
+      <posY>766</posY>
+      <width>53</width>
+      <height>41</height>
+      <texture>starblue_rating.png</texture>
+    	<animation effect="fade" time="250">WindowOpen</animation>
+    	<animation effect="slide" start="0,150" end="0,0" tween="quadratic" easing="in" time="200" delay="0">WindowOpen</animation>
+    	<animation effect="fade" time="0">WindowClose</animation>
+    </control>
+    <control>
+      <id>1</id>
+      <description>PinCode Item 2</description>
+      <type>image</type>
+      <onup>101</onup>
+      <posX>903</posX>
+      <posY>766</posY>
+      <width>53</width>
+      <height>41</height>
+      <texture>starblack_rating.png</texture>
+    	<animation effect="fade" time="250">WindowOpen</animation>
+    	<animation effect="slide" start="0,150" end="0,0" tween="quadratic" easing="in" time="200" delay="0">WindowOpen</animation>
+    	<animation effect="fade" time="0">WindowClose</animation>
+    </control>
+    <control>
+      <id>101</id>
+      <description>PinCode Item 2</description>
+      <type>image</type>
+      <onup>102</onup>
+      <posX>903</posX>
+      <posY>766</posY>
+      <width>53</width>
+      <height>41</height>
+      <texture>starblue_rating.png</texture>
+    	<animation effect="fade" time="250">WindowOpen</animation>
+    	<animation effect="slide" start="0,150" end="0,0" tween="quadratic" easing="in" time="200" delay="0">WindowOpen</animation>
+    	<animation effect="fade" time="0">WindowClose</animation>
+    </control>
+    <control>
+			<id>1</id>
+      <description>PinCode Item 3</description>
+      <type>image</type>
+      <onup>101</onup>
+      <posX>956</posX>
+      <posY>766</posY>
+      <width>53</width>
+      <height>41</height>
+      <texture>starblack_rating.png</texture>
+    	<animation effect="fade" time="250">WindowOpen</animation>
+    	<animation effect="slide" start="0,150" end="0,0" tween="quadratic" easing="in" time="200" delay="0">WindowOpen</animation>
+    	<animation effect="fade" time="0">WindowClose</animation>
+    </control>
+    <control>
+      <id>102</id>
+      <description>PinCode Item 3</description>
+      <type>image</type>
+      <onup>103</onup>
+      <posX>956</posX>
+      <posY>766</posY>
+      <width>53</width>
+      <height>41</height>
+      <texture>starblue_rating.png</texture>
+    	<animation effect="fade" time="250">WindowOpen</animation>
+    	<animation effect="slide" start="0,150" end="0,0" tween="quadratic" easing="in" time="200" delay="0">WindowOpen</animation>
+    	<animation effect="fade" time="0">WindowClose</animation>
+    </control>
+    <control>
+      <id>1</id>
+      <description>PinCode Item 4</description>
+      <type>image</type>
+      <onup>101</onup>
+      <posX>1009</posX>
+      <posY>766</posY>
+      <width>53</width>
+      <height>41</height>
+      <texture>starblack_rating.png</texture>
+    	<animation effect="fade" time="250">WindowOpen</animation>
+    	<animation effect="slide" start="0,150" end="0,0" tween="quadratic" easing="in" time="200" delay="0">WindowOpen</animation>
+    	<animation effect="fade" time="0">WindowClose</animation>
+    </control>
+    <control>
+      <id>103</id>
+      <description>PinCode Item 4</description>
+      <type>image</type>
+      <onup>104</onup>
+      <posX>1009</posX>
+      <posY>766</posY>
+      <width>53</width>
+      <height>41</height>
+      <texture>starblue_rating.png</texture>
+    	<animation effect="fade" time="250">WindowOpen</animation>
+    	<animation effect="slide" start="0,150" end="0,0" tween="quadratic" easing="in" time="200" delay="0">WindowOpen</animation>
+    	<animation effect="fade" time="0">WindowClose</animation>
+    </control>
+    <control>
+      <id>6</id>
+      <description>Feedback</description>
+			<type>label</type>
+			<posX>575</posX>
+			<posY>866</posY>
+			<width>768</width>
+			<align>center</align>
+			<textcolor>ff393939</textcolor>
+    	<animation effect="fade" time="250">WindowOpen</animation>
+    	<animation effect="slide" start="0,150" end="0,0" tween="quadratic" easing="in" time="200" delay="0">WindowOpen</animation>
+    	<animation effect="fade" time="0">WindowClose</animation>
+    </control>
+  </controls>
+</window>

--- a/Common/DialogVideoInfo.xml
+++ b/Common/DialogVideoInfo.xml
@@ -1,0 +1,1316 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<window>
+  <id>2003</id>
+  <defaultcontrol>2</defaultcontrol>
+  <allowoverlay>yes</allowoverlay>
+  <define>#header.label:3</define>
+  <define>#useSelectedFanart:Yes</define>
+  <controls>
+    <control>
+      <description>dummy button for backdrop display</description>
+      <type>button</type>
+      <id>456852</id>
+      <label>-</label>
+      <posX>0</posX>
+      <posY>0</posY>
+      <onup>2</onup>
+      <ondown>2</ondown>
+      <onleft>2</onleft>
+      <onright>2</onright>
+      <visible allowhiddenfocus="true">false</visible>
+      <textcolor>FF000000</textcolor>
+      <textcolorNoFocus>ffffffff</textcolorNoFocus>
+    </control>
+
+    <import>common.default.background.xml</import>
+    <import>common.fanart.selected.xml</import>
+
+    <control>
+      <description>right menu indicator</description>
+      <id>0</id>
+      <type>image</type>
+      <posX>1890</posX>
+      <posY>429</posY>
+      <width>30</width>
+      <height>149</height>
+      <texture>basichome_nextpage_right.png</texture>
+      <visible>control.hasfocus(456852)</visible>
+      <animation effect="slide" start="60,0" end="0,0" tween="quadratic" easing="in" time="250" delay="0">visible</animation>
+      <animation effect="slide" start="0,0" end="60,0" tween="quadratic" easing="in" time="250" delay="0">hidden</animation>
+      <animation effect="fade" time="250">WindowOpen</animation>
+      <animation effect="fade" time="250">WindowClose</animation>
+    </control>
+    <control>
+      <description>left menu indicator</description>
+      <id>0</id>
+      <type>image</type>
+      <posX>0</posX>
+      <posY>429</posY>
+      <width>30</width>
+      <height>149</height>
+      <texture>basichome_nextpage_left.png</texture>
+      <animation effect="slide" start="-60,0" end="0,0" tween="quadratic" easing="in" time="250" delay="0">visible</animation>
+      <animation effect="slide" start="0,0" end="-60,0" tween="quadratic" easing="in" time="250" delay="0">hidden</animation>
+      <animation effect="fade" time="250">WindowOpen</animation>
+      <animation effect="fade" time="250">WindowClose</animation>
+    </control>
+
+    <!-- ClearArt -->
+    <control>
+      <description>ClearArt</description>
+      <type>image</type>
+      <id>0</id>
+      <posX>1550</posX>
+      <posY>150</posY>
+      <width>250</width>
+      <height>140</height>
+      <texture>..\..\..\Thumbs\ClearArt\Movies\#(string.trim(#imdbnumber)).png</texture>
+      <animation effect="fade" time="250" condition="!control.hasfocus(456852)">conditional</animation>
+      <animation effect="fade" time="250">WindowOpen</animation>
+      <animation effect="fade" time="250">WindowClose</animation>
+    </control>
+
+    <!-- ClearLogo -->
+    <control>
+      <description>ClearLogo</description>
+      <type>image</type>
+      <id>0</id>
+      <posX>110</posX>
+      <posY>160</posY>
+      <width>390</width>
+      <height>140</height>
+      <texture>..\..\..\Thumbs\ClearLogo\Movies\#(string.trim(#imdbnumber)).png</texture>
+      <animation effect="fade" time="250" condition="!control.hasfocus(456852)">conditional</animation>
+      <animation effect="fade" time="250">WindowOpen</animation>
+      <animation effect="fade" time="250">WindowClose</animation>
+    </control>
+
+    <control>
+      <description>overlay</description>
+      <type>image</type>
+      <id>0</id>
+      <posX>0</posX>
+      <posY>0</posY>
+      <width>1920</width>
+      <height>1080</height>
+      <texture>fanart_overlay.png</texture>
+      <animation effect="fade" time="250">WindowOpen</animation>
+      <animation effect="fade" time="250">WindowClose</animation>
+      <animation effect="fade" time="250" condition="!control.hasfocus(456852)">conditional</animation>
+    </control>
+
+    <control>
+      <id>0</id>
+      <type>image</type>
+      <posX>60</posX>
+      <posY>34</posY>
+      <width>68</width>
+      <height>60</height>
+      <texture>icon_movies.png</texture>
+      <animation effect="fade" time="250">WindowOpen</animation>
+      <animation effect="fade" time="250">WindowClose</animation>
+    </control>
+
+    <control>
+      <description>panel details plot</description>
+      <type>image</type>
+      <id>0</id>
+      <posX>10</posX>
+      <posY>252</posY>
+      <width>1903</width>
+      <height>790</height>
+      <texture>panel_thumbs_noinfo.png</texture>
+      <visible>!Control.IsVisible(24)</visible>
+      <animation effect="fade" time="250">WindowOpen</animation>
+      <animation effect="fade" time="250">WindowClose</animation>
+      <animation effect="fade" time="250" condition="!control.hasfocus(456852)">conditional</animation>
+    </control>
+
+    <control>
+      <description>panel details actor/movies</description>
+      <type>image</type>
+      <id>0</id>
+      <posX>10</posX>
+      <posY>252</posY>
+      <width>1903</width>
+      <height>790</height>
+      <texture>panel_video_actors.png</texture>
+      <visible>Control.IsVisible(24)</visible>
+      <animation effect="fade" time="250">WindowOpen</animation>
+      <animation effect="fade" time="250">WindowClose</animation>
+      <animation effect="fade" time="250" condition="!control.hasfocus(456852)">conditional</animation>
+    </control>
+
+    <import>common.time.xml</import>
+
+    <control>
+      <description>Poster shadow</description>
+      <type>image</type>
+      <id>1</id>
+      <posX>105</posX>
+      <posY>346</posY>
+      <width>429</width>
+      <height>613</height>
+      <texture>list_poster_shadow.png</texture>
+      <animation effect="fade" time="250">WindowOpen</animation>
+      <animation effect="fade" time="250">WindowClose</animation>
+      <animation effect="fade" time="250" condition="!control.hasfocus(456852)">conditional</animation>
+    </control>
+    <control>
+      <type>image</type>
+      <description>movie poster</description>
+      <id>21</id>
+      <posX>123</posX>
+      <posY>360</posY>
+      <width>379</width>
+      <height>563</height>
+      <texture>#thumb</texture>
+      <animation effect="fade" time="250">WindowOpen</animation>
+      <animation effect="fade" time="250">WindowClose</animation>
+      <animation effect="fade" time="250" condition="!control.hasfocus(456852)">conditional</animation>
+    </control>
+
+	<control>
+      <description>Cover Art Animated</description>
+      <type>image</type>
+      <id>609</id>
+      <posX>123</posX>
+      <posY>360</posY>
+      <width>379</width>
+      <height>563</height>
+      <texture>#fanarthandler.movie.animated.selected.thumb</texture>
+      <animation effect="fade" time="250">WindowOpen</animation>
+      <animation effect="fade" time="250">WindowClose</animation>
+      <animation effect="fade" time="250" condition="!control.hasfocus(456852)">conditional</animation>
+      <visible>system.idletime(10)</visible>
+	</control>
+
+	<control>
+      <description>Cover Art Animated Logo</description>
+      <type>image</type>
+      <id>0</id>
+      <posX>485</posX>
+      <posY>905</posY>
+      <width>15</width>
+      <height>15</height>
+      <texture>icon_animated.png</texture>
+      <visible>!control.IsVisible(609)+!string.equals(#fanarthandler.movie.animated.selected.thumb,)</visible>
+      <animation effect="fade" time="250">WindowOpen</animation>
+      <animation effect="fade" time="250">WindowClose</animation>
+      <animation effect="fade" time="250" condition="!control.hasfocus(456852)">conditional</animation>
+	</control>
+
+    <!-- Rating -->
+    <control>
+      <description>Rating</description>
+      <type>image</type>
+      <id>0</id>
+      <posX>388</posX>
+      <posY>360</posY>
+      <width>114</width>
+      <height>114</height>
+      <texture>Rating#(math.round(cflt(#rating))).png</texture>
+      <animation effect="fade" time="250">WindowOpen</animation>
+      <animation effect="fade" time="250">WindowClose</animation>
+      <animation effect="fade" time="250" condition="!control.hasfocus(456852)">conditional</animation>
+    </control>
+    <control>
+      <description>Rating</description>
+      <type>image</type>
+      <id>0</id>
+      <posX>388</posX>
+      <posY>360</posY>
+      <width>114</width>
+      <height>114</height>
+      <texture>RatingUser#userrating.png</texture>
+      <animation effect="fade" time="250">WindowOpen</animation>
+      <animation effect="fade" time="250">WindowClose</animation>
+      <animation effect="fade" time="250" condition="!control.hasfocus(456852)">conditional</animation>
+    </control>
+
+    <!-- 3D -->
+
+    <control>
+        <description>3D banner</description>
+        <id>0</id>
+        <type>image</type>
+        <posX>381</posX>
+        <posY>360</posY>
+        <width>122</width>
+        <height>122</height>
+        <texture>is3D.png</texture>                                                  
+        <visible>string.equals(#Is3D,yes)</visible>
+    	<animation effect="fade" time="0">WindowOpen</animation>
+		<animation effect="fade" time="0">WindowClose</animation>
+        <animation effect="fade" time="250" condition="!control.hasfocus(456852)">conditional</animation>
+    </control>
+
+    <!-- HDR -->
+
+    <control>
+        <description>HDR banner</description>
+        <id>0</id>
+        <type>image</type>
+        <posX>381</posX>
+        <posY>360</posY>
+        <width>122</width>
+        <height>122</height>
+        <texture>isHDR.png</texture>                                                  
+        <visible>string.equals(#IsHDR,true)</visible>
+    	<animation effect="fade" time="0">WindowOpen</animation>
+		<animation effect="fade" time="0">WindowClose</animation>
+        <animation effect="fade" time="250" condition="!control.hasfocus(456852)">conditional</animation>
+    </control>
+
+    <control>
+      <description>Button group</description>
+      <type>group</type>
+      <animation effect="fade" time="250">WindowOpen</animation>
+      <animation effect="fade" time="250">WindowClose</animation>
+      <posX>571</posX>
+      <posY>360</posY>
+      <layout>StackLayout(6, Vertical, true)</layout>
+      <control>
+        <description>Play Button</description>
+        <type>button</type>
+        <id>2</id>
+        <label>208</label>
+        <!--onup>97270</onup-->
+        <onup>50</onup>
+        <ondown>3</ondown>
+        <onleft>456852</onleft>
+        <onright>10</onright>
+        <textureFocus>myvideos_play_focus.png</textureFocus>
+        <textureNoFocus>myvideos_play_nofocus.png</textureNoFocus>
+        <textcolor>FF000000</textcolor>
+        <textcolorNoFocus>ffffffff</textcolorNoFocus>
+        <animation effect="fade" time="250" condition="!control.hasfocus(456852)">conditional</animation>
+      </control>
+      <control>
+        <description>Plot</description>
+        <type>checkbutton</type>
+        <id>3</id>
+        <label>207</label>
+        <font>font12</font>
+        <textXOff>32</textXOff>
+        <textYOff>12</textYOff>
+        <onup>2</onup>
+        <ondown>4</ondown>
+        <onleft>456852</onleft>
+        <onright>10</onright>
+        <textcolor>FF000000</textcolor>
+        <textcolorNoFocus>ffffffff</textcolorNoFocus>
+        <animation effect="fade" time="250" condition="!control.hasfocus(456852)">conditional</animation>
+      </control>
+      <control>
+        <description>Cast</description>
+        <type>checkbutton</type>
+        <id>4</id>
+        <label>206</label>
+        <font>font12</font>
+        <textXOff>32</textXOff>
+        <textYOff>12</textYOff>
+        <onup>3</onup>
+        <ondown>7</ondown>
+        <onleft>456852</onleft>
+        <onright>24</onright>
+        <textcolor>FF000000</textcolor>
+        <textcolorNoFocus>ffffffff</textcolorNoFocus>
+        <animation effect="fade" time="250" condition="!control.hasfocus(456852)">conditional</animation>
+      </control>
+      <control>
+        <description>User Review Button</description>
+        <type>checkbutton</type>
+        <id>7</id>
+        <label>183</label>
+        <font>font12</font>
+        <textXOff>32</textXOff>
+        <textYOff>12</textYOff>
+        <onup>4</onup>
+        <ondown>6</ondown>
+        <onleft>456852</onleft>
+        <onright>10</onright>
+        <textcolor>FF000000</textcolor>
+        <textcolorNoFocus>ffffffff</textcolorNoFocus>
+        <animation effect="fade" time="250" condition="!control.hasfocus(456852)">conditional</animation>
+      </control>
+      <control>
+        <description>Watched</description>
+        <type>checkbutton</type>
+        <id>6</id>
+        <label>1010</label>
+        <font>font12</font>
+        <textXOff>32</textXOff>
+        <textYOff>12</textYOff>
+        <onup>7</onup>
+        <ondown>5</ondown>
+        <onleft>456852</onleft>
+        <onright>10</onright>
+        <textcolor>FF000000</textcolor>
+        <textcolorNoFocus>ffffffff</textcolorNoFocus>
+        <animation effect="fade" time="250" condition="!control.hasfocus(456852)">conditional</animation>
+      </control>
+      <control>
+        <description>Refresh</description>
+        <type>button</type>
+        <id>5</id>
+        <label>184</label>
+        <onup>6</onup>
+        <ondown>26</ondown>
+        <onleft>456852</onleft>
+        <onright>10</onright>
+        <textcolor>FF000000</textcolor>
+        <textcolorNoFocus>ffffffff</textcolorNoFocus>
+        <animation effect="fade" time="250" condition="!control.hasfocus(456852)">conditional</animation>
+      </control>
+      <control>
+        <description>Rename Title Button</description>
+        <type>button</type>
+        <id>26</id>
+        <label>118</label>
+        <onup>5</onup>
+        <!--ondown>2</ondown-->
+        <onleft>456852</onleft>
+        <onright>10</onright>
+        <textcolor>FF000000</textcolor>
+        <textcolorNoFocus>ffffffff</textcolorNoFocus>
+        <animation effect="fade" time="250" condition="!control.hasfocus(456852)">conditional</animation>
+      </control>
+    </control>
+
+    <control>
+      <description>Button group</description>
+      <type>group</type>
+      <animation effect="fade" time="250">WindowOpen</animation>
+      <animation effect="fade" time="250">WindowClose</animation>
+      <posX>571</posX>
+      <posY>807</posY>
+      <layout>StackLayout(3, Horizontal, true)</layout>
+      <control>
+        <description>Awards Button</description>
+        <type>checkbutton</type>
+        <id>50</id>
+        <label></label>
+        <width>93</width>
+        <textureFocus>icon_awards_focus.png</textureFocus>
+        <textureNoFocus>icon_awards_nofocus.png</textureNoFocus>
+        <onup>26</onup>
+        <ondown>10</ondown>
+        <onleft>456852</onleft>
+        <onright>52</onright>
+        <textureCheckmark>icon_small_checkmark_checked.png</textureCheckmark>
+        <textureCheckmarkNoFocus>icon_small_checkmark_unchecked.png</textureCheckmarkNoFocus>
+        <textcolor>FF000000</textcolor>
+        <textcolorNoFocus>ffffffff</textcolorNoFocus>
+        <markWidth>93</markWidth>
+        <markHeight>58</markHeight>
+        <markXOff>-5</markXOff>
+        <markYOff>0</markYOff>
+        <markalign>left</markalign>
+        <markvalign>top</markvalign>
+        <animation effect="fade" time="250" condition="!control.hasfocus(456852)">conditional</animation>
+      </control>
+      <control>
+        <description>MPAA Button</description>
+        <type>checkbutton</type>
+        <id>52</id>
+        <label></label>
+        <width>93</width>
+        <textureFocus>icon_mpaa_focus.png</textureFocus>
+        <textureNoFocus>icon_mpaa_nofocus.png</textureNoFocus>
+        <onup>26</onup>
+        <ondown>10</ondown>
+        <onleft>50</onleft>
+        <onright>97270</onright>
+        <textureCheckmark>icon_small_checkmark_checked.png</textureCheckmark>
+        <textureCheckmarkNoFocus>icon_small_checkmark_unchecked.png</textureCheckmarkNoFocus>
+        <textcolor>FF000000</textcolor>
+        <textcolorNoFocus>ffffffff</textcolorNoFocus>
+        <markWidth>93</markWidth>
+        <markHeight>58</markHeight>
+        <markXOff>-5</markXOff>
+        <markYOff>0</markYOff>
+        <markalign>left</markalign>
+        <markvalign>top</markvalign>
+        <animation effect="fade" time="250" condition="!control.hasfocus(456852)">conditional</animation>
+      </control>
+      <control>
+        <description>Trakt Button</description>
+        <type>button</type>
+        <id>97270</id>
+        <label></label>
+        <width>93</width>
+        <textureFocus>icon_trakt_focus.png</textureFocus>
+        <textureNoFocus>icon_trakt_nofocus.png</textureNoFocus>
+        <onup>26</onup>
+        <ondown>10</ondown>
+        <onleft>52</onleft>
+        <onright>11899</onright>
+        <textureCheckmark>icon_small_checkmark_checked.png</textureCheckmark>
+        <textureCheckmarkNoFocus>icon_small_checkmark_unchecked.png</textureCheckmarkNoFocus>
+        <textcolor>FF000000</textcolor>
+        <textcolorNoFocus>ffffffff</textcolorNoFocus>
+        <visible>plugin.isenabled(Trakt)</visible>
+        <markWidth>93</markWidth>
+        <markHeight>58</markHeight>
+        <markXOff>-5</markXOff>
+        <markYOff>0</markYOff>
+        <markalign>left</markalign>
+        <markvalign>top</markvalign>
+        <animation effect="fade" time="250" condition="!control.hasfocus(456852)">conditional</animation>
+      </control>
+      <control>
+        <description>Trailers</description>
+        <type>button</type>
+        <id>11899</id>
+        <label></label>
+        <width>93</width>
+        <textureFocus>icon_trailers_focus.png</textureFocus>
+        <textureNoFocus>icon_trailers_nofocus.png</textureNoFocus>
+        <onup>26</onup>
+        <ondown>10</ondown>
+        <onleft>97270</onleft>
+        <onright>4755</onright>
+        <textureCheckmark>icon_small_checkmark_checked.png</textureCheckmark>
+        <textureCheckmarkNoFocus>icon_small_checkmark_unchecked.png</textureCheckmarkNoFocus>
+        <textcolor>FF000000</textcolor>
+        <textcolorNoFocus>ffffffff</textcolorNoFocus>
+        <visible>plugin.isenabled(Trailers)</visible>
+        <markWidth>93</markWidth>
+        <markHeight>58</markHeight>
+        <markXOff>-5</markXOff>
+        <markYOff>0</markYOff>
+        <markalign>left</markalign>
+        <markvalign>top</markvalign>
+        <animation effect="fade" time="250" condition="!control.hasfocus(456852)">conditional</animation>
+      </control>
+      <control>
+        <description>IMDb Trailer Button (Online Videos)</description>
+        <type>button</type>
+        <id>4755</id>
+        <label></label>
+        <hyperlink>4755</hyperlink>
+        <hyperlinkParameter>site:IMDb Movie Trailers|search:#(iif(neq(#imdbnumber,''),#imdbnumber,#title))|return:Locked</hyperlinkParameter>
+        <width>93</width>
+        <textureFocus>icon_trailers_focus.png</textureFocus>
+        <textureNoFocus>icon_trailers_nofocus.png</textureNoFocus>
+        <onleft>11899</onleft>
+        <onup>26</onup>
+        <ondown>10</ondown>
+        <onright>50</onright>
+        <textureCheckmark>icon_small_checkmark_checked.png</textureCheckmark>
+        <textureCheckmarkNoFocus>icon_small_checkmark_unchecked.png</textureCheckmarkNoFocus>
+        <textcolor>FF000000</textcolor>
+        <textcolorNoFocus>ffffffff</textcolorNoFocus>
+        <visible>!plugin.isenabled(Trailers)+plugin.isenabled(OnlineVideos)</visible>
+        <markWidth>93</markWidth>
+        <markHeight>58</markHeight>
+        <markXOff>-5</markXOff>
+        <markYOff>0</markYOff>
+        <markalign>left</markalign>
+        <markvalign>top</markvalign>
+        <animation effect="fade" time="250" condition="!control.hasfocus(456852)">conditional</animation>
+      </control>
+    </control>
+
+    <control>
+      <description>spin control background 1</description>
+      <type>image</type>
+      <id>117</id>
+      <posX>-2000</posX>
+      <posY>442</posY>
+      <texture>-</texture>
+      <visible>!Control.HasFocus(10)</visible>
+      <animation effect="fade" time="250" condition="!control.hasfocus(456852)">conditional</animation>
+    </control>
+    <control>
+      <description>spin control background 2</description>
+      <type>image</type>
+      <id>117</id>
+      <posX>-2000</posX>
+      <posY>442</posY>
+      <width>239</width>
+      <height>36</height>
+      <texture>settings_button_medium_focus.png</texture>
+      <visible>Control.HasFocus(10)</visible>
+      <animation effect="fade" time="250" condition="!control.hasfocus(456852)">conditional</animation>
+    </control>
+    <control>
+      <description>spin control background 3</description>
+      <type>image</type>
+      <id>117</id>
+      <posX>-2000</posX>
+      <posY>493</posY>
+      <texture>-</texture>
+      <visible>!Control.HasFocus(11)</visible>
+      <animation effect="fade" time="250" condition="!control.hasfocus(456852)">conditional</animation>
+    </control>
+    <control>
+      <description>spin control background 4</description>
+      <type>image</type>
+      <id>117</id>
+      <posX>-2000</posX>
+      <posY>493</posY>
+      <width>239</width>
+      <height>36</height>
+      <texture>settings_button_medium_focus.png</texture>
+      <visible>Control.HasFocus(11)</visible>
+      <animation effect="fade" time="250" condition="!control.hasfocus(456852)">conditional</animation>
+    </control>
+
+    <control>
+      <description>image title:</description>
+      <type>label</type>
+      <id>30</id>
+      <posX>602</posX>
+      <posY>878</posY>
+      <label>734</label>
+      <animation effect="fade" time="250">WindowOpen</animation>
+      <animation effect="fade" time="250">WindowClose</animation>
+      <textalign>left</textalign>
+      <animation effect="fade" time="250" condition="!control.hasfocus(456852)">conditional</animation>
+      <visible>Control.IsVisible(10)</visible>
+    </control>
+    <control>
+      <description>spin control</description>
+      <type>spincontrol</type>
+      <id>10</id>
+      <posX>895</posX>
+      <posY>888</posY>
+      <onup>2</onup>
+      <ondown>11</ondown>
+      <align>right</align>
+      <buddycontrolid>30</buddycontrolid>
+      <textcolor>ffffffff</textcolor>
+      <disabledcolor>ffffffff</disabledcolor>
+      <animation effect="fade" time="250">WindowOpen</animation>
+      <animation effect="fade" time="250">WindowClose</animation>
+      <animation effect="fade" time="250" condition="!control.hasfocus(456852)">conditional</animation>
+    </control>
+
+    <control>
+      <description>disc:</description>
+      <type>label</type>
+      <id>100</id>
+      <posX>602</posX>
+      <posY>923</posY>
+      <label>427</label>
+      <animation effect="fade" time="250">WindowOpen</animation>
+      <animation effect="fade" time="250">WindowClose</animation>
+      <textalign>right</textalign>
+      <animation effect="fade" time="250" condition="!control.hasfocus(456852)">conditional</animation>
+      <visible>Control.IsVisible(11)</visible>
+    </control>
+    <control>
+      <description>disc select</description>
+      <type>spincontrol</type>
+      <id>11</id>
+      <posX>895</posX>
+      <posY>934</posY>
+      <onup>10</onup>
+      <ondown>2</ondown>
+      <onleft>5</onleft>
+      <onright>5</onright>
+      <align>right</align>
+      <textcolor>ffffffff</textcolor>
+      <disabledcolor>ffffffff</disabledcolor>
+      <buddycontrolid>100</buddycontrolid>
+      <showrange>no</showrange>
+      <animation effect="fade" time="250">WindowOpen</animation>
+      <animation effect="fade" time="250">WindowClose</animation>
+      <animation effect="fade" time="250" condition="!control.hasfocus(456852)">conditional</animation>
+    </control>
+
+    <control>
+      <description>Movie Title value</description>
+      <type>fadelabel</type>
+      <id>1</id>
+      <posX>1020</posX>
+      <posY>352</posY>
+      <width>800</width>
+      <label>#title</label>
+      <font>fontB20</font>
+      <textcolor>FF00b7ff</textcolor>
+      <shadowAngle>120</shadowAngle>
+      <shadowDistance>2</shadowDistance>
+      <shadowColor>FF000000</shadowColor>
+      <visible>!Control.IsVisible(24)+!Control.IsVisible(23)+!Control.IsVisible(51)+!Control.IsVisible(53)</visible>
+      <animation effect="fade" time="250">WindowOpen</animation>
+      <animation effect="fade" time="250">WindowClose</animation>
+      <animation effect="fade" time="250" condition="!control.hasfocus(456852)">conditional</animation>
+    </control>
+    <control Style="InfoLabelDetails">
+      <description>Year label</description>
+      <type>label</type>
+      <id>1</id>
+      <label>#(string.rtrim(L(172),' :'))</label>
+      <posX>1020</posX>
+      <posY>467</posY>
+      <visible>!Control.IsVisible(24)+!Control.IsVisible(23)+!Control.IsVisible(51)+!Control.IsVisible(53)</visible>
+      <animation effect="fade" time="250">WindowOpen</animation>
+      <animation effect="fade" time="250">WindowClose</animation>
+      <animation effect="fade" time="250" condition="!control.hasfocus(456852)">conditional</animation>
+    </control>
+    <control Style="InfoValueWide">
+      <description>Year value</description>
+      <type>label</type>
+      <id>1</id>
+      <label>#year</label>
+      <posX>1273</posX>
+      <posY>467</posY>
+      <visible>!Control.IsVisible(24)+!Control.IsVisible(23)+!Control.IsVisible(51)+!Control.IsVisible(53)</visible>
+      <animation effect="fade" time="250">WindowOpen</animation>
+      <animation effect="fade" time="250">WindowClose</animation>
+      <animation effect="fade" time="250" condition="!control.hasfocus(456852)">conditional</animation>
+    </control>
+    <control Style="InfoLabelDetails">
+      <description>Genre label</description>
+      <type>label</type>
+      <id>1</id>
+      <label>725</label>
+      <posX>1020</posX>
+      <posY>531</posY>
+      <visible>!Control.IsVisible(24)+!Control.IsVisible(23)+!Control.IsVisible(51)+!Control.IsVisible(53)</visible>
+      <animation effect="fade" time="250">WindowOpen</animation>
+      <animation effect="fade" time="250">WindowClose</animation>
+      <animation effect="fade" time="250" condition="!control.hasfocus(456852)">conditional</animation>
+    </control>
+    <control Style="InfoValueWide">
+      <description>Genre value</description>
+      <type>label</type>
+      <id>1</id>
+      <label>#genre</label>
+      <posX>1273</posX>
+      <posY>531</posY>
+      <visible>!Control.IsVisible(24)+!Control.IsVisible(23)+!Control.IsVisible(51)+!Control.IsVisible(53)</visible>
+      <animation effect="fade" time="250">WindowOpen</animation>
+      <animation effect="fade" time="250">WindowClose</animation>
+      <animation effect="fade" time="250" condition="!control.hasfocus(456852)">conditional</animation>
+    </control>
+    <control Style="InfoLabelDetails">
+      <description>Runtime label</description>
+      <type>label</type>
+      <id>1</id>
+      <label>#(string.rtrim(L(299),' :'))</label>
+      <posX>1020</posX>
+      <posY>499</posY>
+      <visible>!Control.IsVisible(24)+!Control.IsVisible(23)+!Control.IsVisible(51)+!Control.IsVisible(53)</visible>
+      <animation effect="fade" time="250">WindowOpen</animation>
+      <animation effect="fade" time="250">WindowClose</animation>
+      <animation effect="fade" time="250" condition="!control.hasfocus(456852)">conditional</animation>
+    </control>
+    <control Style="InfoValueWide">
+      <description>Runtime value</description>
+      <type>label</type>
+      <id>1</id>
+      <label>#runtime</label>
+      <posX>1273</posX>
+      <posY>499</posY>
+      <visible>!Control.IsVisible(24)+!Control.IsVisible(23)+!Control.IsVisible(51)+!Control.IsVisible(53)</visible>
+      <animation effect="fade" time="250">WindowOpen</animation>
+      <animation effect="fade" time="250">WindowClose</animation>
+      <animation effect="fade" time="250" condition="!control.hasfocus(456852)">conditional</animation>
+    </control>
+    <control Style="InfoLabelDetails">
+      <description>Director label</description>
+      <type>label</type>
+      <id>1</id>
+      <label>#(string.rtrim(L(199),' :'))</label>
+      <posX>1020</posX>
+      <posY>563</posY>
+      <visible>!Control.IsVisible(24)+!Control.IsVisible(23)+!Control.IsVisible(51)+!Control.IsVisible(53)</visible>
+      <animation effect="fade" time="250">WindowOpen</animation>
+      <animation effect="fade" time="250">WindowClose</animation>
+      <animation effect="fade" time="250" condition="!control.hasfocus(456852)">conditional</animation>
+    </control>
+    <control Style="InfoValueWide">
+      <description>Director value</description>
+      <type>label</type>
+      <id>1</id>
+      <posX>1273</posX>
+      <posY>563</posY>
+      <label>#director</label>
+      <visible>!Control.IsVisible(24)+!Control.IsVisible(23)+!Control.IsVisible(51)+!Control.IsVisible(53)</visible>
+      <animation effect="fade" time="250">WindowOpen</animation>
+      <animation effect="fade" time="250">WindowClose</animation>
+      <animation effect="fade" time="250" condition="!control.hasfocus(456852)">conditional</animation>
+    </control>
+    <control Style="InfoLabelDetails">
+      <description>Writers Label</description>
+      <type>label</type>
+      <id>1</id>
+      <posX>1020</posX>
+      <posY>595</posY>
+      <label>#(string.rtrim(L(200),' :'))</label>
+      <visible>!Control.IsVisible(24)+!Control.IsVisible(23)+!Control.IsVisible(51)+!Control.IsVisible(53)</visible>
+      <animation effect="fade" time="250">WindowOpen</animation>
+      <animation effect="fade" time="250">WindowClose</animation>
+      <animation effect="fade" time="250" condition="!control.hasfocus(456852)">conditional</animation>
+    </control>
+    <control Style="InfoValueWide">
+      <description>Writers Value</description>
+      <type>fadelabel</type>
+      <id>1</id>
+      <posX>1273</posX>
+      <posY>595</posY>
+      <width>580</width>
+      <label>#credits</label>
+      <visible>!Control.IsVisible(24)+!Control.IsVisible(23)+!Control.IsVisible(51)+!Control.IsVisible(53)</visible>
+      <animation effect="fade" time="250">WindowOpen</animation>
+      <animation effect="fade" time="250">WindowClose</animation>
+      <animation effect="fade" time="250" condition="!control.hasfocus(456852)">conditional</animation>
+    </control>
+    <control Style="InfoLabelDetails">
+      <description>Studios Label</description>
+      <type>label</type>
+      <id>1</id>
+      <posX>1020</posX>
+      <posY>627</posY>
+      <label>#(string.rtrim(L(1274),' :'))</label>
+      <visible>!Control.IsVisible(24)+!Control.IsVisible(23)+!Control.IsVisible(51)+!Control.IsVisible(53)</visible>
+      <animation effect="fade" time="250">WindowOpen</animation>
+      <animation effect="fade" time="250">WindowClose</animation>
+      <animation effect="fade" time="250" condition="!control.hasfocus(456852)">conditional</animation>
+    </control>
+    <control Style="InfoValueWide">
+      <description>Studios Value</description>
+      <type>fadelabel</type>
+      <id>1</id>
+      <posX>1273</posX>
+      <posY>627</posY>
+      <width>560</width>
+      <label>#studios</label>
+      <visible>!Control.IsVisible(24)+!Control.IsVisible(23)+!Control.IsVisible(51)+!Control.IsVisible(53)</visible>
+      <animation effect="fade" time="250">WindowOpen</animation>
+      <animation effect="fade" time="250">WindowClose</animation>
+      <animation effect="fade" time="250" condition="!control.hasfocus(456852)">conditional</animation>
+    </control>
+    <control>
+      <description>Rating label</description>
+      <type>label</type>
+      <id>1</id>
+      <label>#rating</label>
+      <posX>1348</posX>
+      <posY>423</posY>
+      <width>240</width>
+      <align>left</align>
+      <font>fontB12</font>
+      <textcolor>FF00b7ff</textcolor>
+      <visible>!Control.IsVisible(24)+!Control.IsVisible(23)+!Control.IsVisible(51)+!Control.IsVisible(53)</visible>
+      <animation effect="fade" time="250">WindowOpen</animation>
+      <animation effect="fade" time="250">WindowClose</animation>
+      <animation effect="fade" time="250" condition="!control.hasfocus(456852)">conditional</animation>
+    </control>
+    <control>
+      <type>imagelist</type>
+      <id>1</id>
+      <posX>1017</posX>
+      <posY>425</posY>
+      <width>315</width>
+      <height>29</height>
+      <textureWidth>32</textureWidth>
+      <textureHeight>27</textureHeight>
+      <subitems>
+        <subitem>starblack.png</subitem>
+        <subitem>starblue.png</subitem>
+      </subitems>
+      <orientation>horizontal</orientation>
+      <align>left</align>
+      <imagesToDraw>10</imagesToDraw>
+      <percentage>#rating</percentage>
+      <visible>!Control.IsVisible(24)+!Control.IsVisible(23)+!Control.IsVisible(51)+!Control.IsVisible(53)</visible>
+      <animation effect="fade" time="250">WindowOpen</animation>
+      <animation effect="fade" time="250">WindowClose</animation>
+      <animation effect="fade" time="250" condition="!control.hasfocus(456852)">conditional</animation>
+    </control>
+
+    <control Style="textBoxDetails">
+      <description>Plot value</description>
+      <type>textboxscrollup</type>
+      <id>20</id>
+      <posX>1020</posX>
+      <posY>670</posY>
+      <height>180</height>
+      <width>800</width>
+      <onleft>2</onleft>
+      <onright>2</onright>
+      <onup>2</onup>
+      <ondown>2</ondown>
+      <label>#plot</label>
+      <seperator>---------------------------------------------------------------------------------------------------------</seperator>
+      <animation effect="fade" time="250">WindowOpen</animation>
+      <animation effect="fade" time="250">WindowClose</animation>
+      <animation effect="fade" time="250" condition="!control.hasfocus(456852)">conditional</animation>
+    </control>
+
+    <control>
+      <description>textarea</description>
+      <type>textbox</type>
+      <id>22</id>
+      <posX>1020</posX>
+      <posY>670</posY>
+      <height>240</height>
+      <width>750</width>
+      <onleft>2</onleft>
+      <onright>2</onright>
+      <onup>2</onup>
+      <ondown>2</ondown>
+      <label>#cast</label>
+      <spinWidth>18</spinWidth>
+      <spinHeight>16</spinHeight>
+      <spinPosX>1776</spinPosX>
+      <spinPosY>832</spinPosY>
+      <spinAlign>right</spinAlign>
+      <spinColor>FFFFFFFF</spinColor>
+      <animation effect="fade" time="250">WindowOpen</animation>
+      <animation effect="fade" time="250">WindowClose</animation>
+      <animation effect="fade" time="250" condition="!control.hasfocus(456852)">conditional</animation>
+    </control>
+
+    <control Style="textBoxDetails">
+      <description>Review value</description>
+      <type>textboxscrollup</type>
+      <id>23</id>
+      <posX>1020</posX>
+      <posY>360</posY>
+      <height>490</height>
+      <width>800</width>
+      <onleft>2</onleft>
+      <onright>2</onright>
+      <onup>2</onup>
+      <ondown>2</ondown>
+      <label>#userreview</label>
+      <seperator>---------------------------------------------------------------------------------------------------------</seperator>
+      <animation effect="fade" time="250">WindowOpen</animation>
+      <animation effect="fade" time="250">WindowClose</animation>
+      <animation effect="fade" time="250" condition="!control.hasfocus(456852)">conditional</animation>
+    </control>
+
+    <control Style="textBoxDetails">
+      <description>Awards value</description>
+      <type>textboxscrollup</type>
+      <id>51</id>
+      <posX>1020</posX>
+      <posY>360</posY>
+      <height>490</height>
+      <width>800</width>
+      <onleft>2</onleft>
+      <onright>2</onright>
+      <onup>2</onup>
+      <ondown>2</ondown>
+      <label>#awards</label>
+      <seperator>---------------------------------------------------------------------------------------------------------</seperator>
+      <animation effect="fade" time="250">WindowOpen</animation>
+      <animation effect="fade" time="250">WindowClose</animation>
+      <animation effect="fade" time="250" condition="!control.hasfocus(456852)">conditional</animation>
+    </control>
+
+    <control Style="textBoxDetails">
+      <description>MPAA value</description>
+      <type>textboxscrollup</type>
+      <id>53</id>
+      <posX>1020</posX>
+      <posY>360</posY>
+      <height>490</height>
+      <width>800</width>
+      <onleft>2</onleft>
+      <onright>2</onright>
+      <onup>2</onup>
+      <ondown>2</ondown>
+      <label>#mpaatext</label>
+      <seperator>---------------------------------------------------------------------------------------------------------</seperator>
+      <animation effect="fade" time="250">WindowOpen</animation>
+      <animation effect="fade" time="250">WindowClose</animation>
+      <animation effect="fade" time="250" condition="!control.hasfocus(456852)">conditional</animation>
+    </control>
+
+    <control>
+      <description>frame</description>
+      <type>image</type>
+      <id>0</id>
+      <posX>1025</posX>
+      <posY>876</posY>
+      <width>550</width>
+      <height>73</height>
+      <texture>logoframe.png</texture>
+      <visible>!Control.IsVisible(24)</visible>
+      <animation effect="fade" time="250">WindowOpen</animation>
+      <animation effect="fade" time="250">WindowClose</animation>
+      <animation effect="fade" time="250" condition="!control.hasfocus(456852)">conditional</animation>
+    </control>
+
+    <control Style="smallTitle">
+      <description>Selected item Label</description>
+      <type>fadelabel</type>
+      <id>1</id>
+      <posX>510</posX>
+      <posY>1015</posY>
+      <label>#title</label>
+      <visible>!Control.IsVisible(24)</visible>
+      <animation effect="fade" start="0" end="100" time="300" delay="350">WindowOpen</animation>
+      <animation effect="fade" start="100" end="0" time="0" delay="0">WindowClose</animation>
+      <animation effect="fade" time="250" condition="!control.hasfocus(456852)">conditional</animation>
+    </control>
+
+    <control>
+      <description>Plot label</description>
+      <type>label</type>
+      <id>1</id>
+      <label>207</label>
+      <posX>1815</posX>
+      <posY>998</posY>
+      <font>TitanLight12</font>
+      <align>right</align>
+      <textcolor>000000</textcolor>
+      <visible>!Control.IsVisible(24)</visible>
+      <animation effect="fade" time="250">WindowOpen</animation>
+      <animation effect="fade" time="250">WindowClose</animation>
+      <animation effect="fade" time="250" condition="!control.hasfocus(456852)">conditional</animation>
+    </control>
+
+    <control>
+      <description>Movie Title Actor view</description>
+      <type>fadelabel</type>
+      <label>#title</label>
+      <id>0</id>
+      <posX>96</posX>
+      <posY>998</posY>
+      <align>left</align>
+      <width>450</width>
+      <font>TitanLight12</font>
+      <textcolor>000000</textcolor>
+      <visible>Control.IsVisible(24)</visible>
+      <animation effect="fade" time="250">WindowOpen</animation>
+      <animation effect="fade" time="250">WindowClose</animation>
+      <animation effect="fade" time="250" condition="!control.hasfocus(456852)">conditional</animation>
+    </control>
+
+    <control Style="smallTitle">
+      <description>Selected actor Label</description>
+      <type>fadelabel</type>
+      <id>1</id>
+      <posX>510</posX>
+      <posY>1015</posY>
+      <label>#selecteditem</label>
+      <visible>Control.IsVisible(24)</visible>
+      <animation effect="fade" start="0" end="100" time="300" delay="350">WindowOpen</animation>
+      <animation effect="fade" start="100" end="0" time="0" delay="0">WindowClose</animation>
+      <animation effect="fade" time="250" condition="!control.hasfocus(456852)">conditional</animation>
+    </control>
+
+    <control>
+      <description>Actor label</description>
+      <type>label</type>
+      <id>1</id>
+      <label>344</label>
+      <posX>1815</posX>
+      <posY>998</posY>
+      <font>TitanLight12</font>
+      <align>right</align>
+      <textcolor>000000</textcolor>
+      <visible>Control.IsVisible(24)</visible>
+      <animation effect="fade" time="250">WindowOpen</animation>
+      <animation effect="fade" time="250">WindowClose</animation>
+      <animation effect="fade" time="250" condition="!control.hasfocus(456852)">conditional</animation>
+    </control>
+
+    <control>
+      <description>Actors/Cast Image</description>
+      <type>image</type>
+      <id>25</id>
+      <!--posX>1676</posX>
+      <posY>359</posY>
+      <width>158</width>
+      <height>235</height-->
+      <posX>123</posX>
+      <posY>360</posY>
+      <width>379</width>
+      <height>563</height>
+      <keepaspectratio>no</keepaspectratio>
+      <texture>#actorThumb</texture>
+      <animation effect="fade" time="250">WindowOpen</animation>
+      <animation effect="fade" time="250">WindowClose</animation>
+      <animation effect="fade" time="250" condition="!control.hasfocus(456852)">conditional</animation>
+    </control>
+
+    <control>
+      <description>Actors/Cast List</description>
+      <type>listcontrol</type>
+      <id>24</id>
+      <posX>1022</posX>
+      <posY>360</posY>
+      <height>610</height>
+      <width>835</width>
+      <onleft>4</onleft>
+      <onright>4</onright>
+      <scrollOffset>2</scrollOffset>
+      <spinPosX>-2000</spinPosX>
+      <spinPosY>680</spinPosY>
+      <spinCanFocus>no</spinCanFocus>
+      <unfocusedAlpha>255</unfocusedAlpha>
+      <textcolor>ff85cffe</textcolor>
+      <font>TitanLight12</font>
+      <textvisible2>no</textvisible2>
+      <textvisible3>no</textvisible3>
+      <keepaspectratio>yes</keepaspectratio>
+      <animation effect="fade" time="250">WindowOpen</animation>
+      <animation effect="fade" time="250">WindowClose</animation>
+      <animation effect="fade" time="250" condition="!control.hasfocus(456852)">conditional</animation>
+    </control>
+
+    <!--            :: MEDIAINFO ::            -->
+    <control>
+      <description>Certification (MPAA) Logo</description>
+      <type>image</type>
+      <id>0</id>
+      <posX>1046</posX>
+      <posY>887</posY>
+      <width>50</width>
+      <height>50</height>
+      <texture>certification\#mpaarating.png</texture>
+      <keepaspectratio>yes</keepaspectratio>
+      <visible>!Control.IsVisible(24)</visible>
+      <animation effect="fade" time="250">WindowOpen</animation>
+      <animation effect="fade" time="250">WindowClose</animation>
+      <animation effect="fade" time="250" condition="!control.hasfocus(456852)">conditional</animation>
+    </control>
+    <control>
+      <description>Certification (MPAA) Logo</description>
+      <type>image</type>
+      <id>0</id>
+      <posX>1620</posX>
+      <posY>887</posY>
+      <width>220</width>
+      <height>50</height>
+      <texture>certification\mpaa\#mpaarating.png</texture>
+      <keepaspectratio>yes</keepaspectratio>
+      <visible>!Control.IsVisible(24)</visible>
+      <animation effect="fade" time="250">WindowOpen</animation>
+      <animation effect="fade" time="250">WindowClose</animation>
+      <animation effect="fade" time="250" condition="!control.hasfocus(456852)">conditional</animation>
+    </control>
+    <control>
+      <description>Video resolution</description>
+      <type>image</type>
+      <id>0</id>
+      <posX>1123</posX>
+      <posY>880</posY>
+      <width>99</width>
+      <height>65</height>
+      <texture>Logos\resolution\#VideoResolution.png</texture>
+      <keepaspectratio>yes</keepaspectratio>
+      <visible>!Control.IsVisible(24)</visible>
+      <animation effect="fade" time="250">WindowOpen</animation>
+      <animation effect="fade" time="250">WindowClose</animation>
+      <animation effect="fade" time="250" condition="!control.hasfocus(456852)">conditional</animation>
+    </control>
+    <control>
+      <description>Video codec</description>
+      <type>image</type>
+      <id>0</id>
+      <posX>1208</posX>
+      <posY>880</posY>
+      <width>99</width>
+      <height>65</height>
+      <texture>Logos\video\#VideoCodec.png</texture>
+      <keepaspectratio>yes</keepaspectratio>
+      <visible>!Control.IsVisible(24)</visible>
+      <animation effect="fade" time="250">WindowOpen</animation>
+      <animation effect="fade" time="250">WindowClose</animation>
+      <animation effect="fade" time="250" condition="!control.hasfocus(456852)">conditional</animation>
+    </control>
+    <control>
+      <description>Audio codec</description>
+      <type>image</type>
+      <id>0</id>
+      <posX>1308</posX>
+      <posY>880</posY>
+      <width>99</width>
+      <height>65</height>
+      <texture>Logos\audio\#AudioCodec.png</texture>
+      <keepaspectratio>yes</keepaspectratio>
+      <visible>!Control.IsVisible(24)</visible>
+      <animation effect="fade" time="250">WindowOpen</animation>
+      <animation effect="fade" time="250">WindowClose</animation>
+      <animation effect="fade" time="250" condition="!control.hasfocus(456852)">conditional</animation>
+    </control>
+    <control>
+      <description>Audio channels</description>
+      <type>image</type>
+      <id>0</id>
+      <posX>1410</posX>
+      <posY>880</posY>
+      <width>99</width>
+      <height>65</height>
+      <texture>Logos\audio\#AudioChannels.png</texture>
+      <keepaspectratio>yes</keepaspectratio>
+      <visible>!Control.IsVisible(24)</visible>
+      <animation effect="fade" time="250">WindowOpen</animation>
+      <animation effect="fade" time="250">WindowClose</animation>
+      <animation effect="fade" time="250" condition="!control.hasfocus(456852)">conditional</animation>
+    </control>
+    <control>
+      <description>Aspect ratio</description>
+      <type>image</type>
+      <id>0</id>
+      <posX>1508</posX>
+      <posY>880</posY>
+      <width>99</width>
+      <height>65</height>
+      <texture>Logos\aspectratio\#AspectRatio.png</texture>
+      <keepaspectratio>yes</keepaspectratio>
+      <visible>!Control.IsVisible(24)</visible>
+      <animation effect="fade" time="250">WindowOpen</animation>
+      <animation effect="fade" time="250">WindowClose</animation>
+      <animation effect="fade" time="250" condition="!control.hasfocus(456852)">conditional</animation>
+    </control>
+
+    <!-- Studio logos -->
+    <control>
+      <description>Studios Logos</description>
+      <id>5551555</id>
+      <type>image</type>
+      <texture>#fanarthandler.movie.studios.selected.all</texture>
+      <posX>123</posX>
+      <posY>925</posY>
+      <width>379</width>
+      <height>60</height>
+      <align>center</align>
+      <valign>top</valign>
+      <!--zoom>false</zoom-->
+      <keepaspectratio>yes</keepaspectratio>
+      <!--fixedheight>false</fixedheight-->
+      <shouldCache>true</shouldCache>
+      <visible>!Control.IsVisible(24)</visible>
+      <animation effect="fade" time="250">WindowOpen</animation>
+      <animation effect="fade" time="250">WindowClose</animation>
+      <animation effect="fade" time="250" condition="!control.hasfocus(456852)">conditional</animation>
+    </control>
+    <control>
+      <description>Studio Logo</description>
+      <type>image</type>
+      <id>5550555</id>
+      <posX>265</posX>
+      <posY>920</posY>
+      <width>100</width>
+      <height>65</height>
+      <texture>#fanarthandler.movie.studios.selected</texture>
+      <keepaspectratio>yes</keepaspectratio>
+      <visible>!Control.IsVisible(24)+!control.hasthumb(5551555)</visible>
+      <animation effect="fade" time="250">WindowOpen</animation>
+      <animation effect="fade" time="250">WindowClose</animation>
+      <animation effect="fade" time="250" condition="!control.hasfocus(456852)">conditional</animation>
+    </control>
+    <control>
+      <description>Studio Logo</description>
+      <type>image</type>
+      <id>0</id>
+      <posX>265</posX>
+      <posY>920</posY>
+      <width>100</width>
+      <height>65</height>
+      <texture>Logos\Studios\#(string.trim(#studios)).png</texture>
+      <keepaspectratio>yes</keepaspectratio>
+      <visible>!Control.IsVisible(24)+!control.hasthumb(5550555)</visible>
+      <animation effect="fade" time="250">WindowOpen</animation>
+      <animation effect="fade" time="250">WindowClose</animation>
+      <animation effect="fade" time="250" condition="!control.hasfocus(456852)">conditional</animation>
+    </control>
+
+    <!-- Genre logos -->
+    <control>
+      <description>Genres Logo</description>
+      <type>image</type>
+      <id>0</id>
+      <posX>85</posX>
+      <posY>360</posY>
+      <width>30</width>
+      <height>560</height>
+      <align>center</align>
+      <valign>bottom</valign>
+      <keepaspectratio>yes</keepaspectratio>
+      <shouldCache>true</shouldCache>
+      <texture>#fanarthandler.movie.genres.selected.verticalall</texture>
+      <visible>!Control.IsVisible(24)</visible>
+      <animation effect="fade" time="250">WindowOpen</animation>
+      <animation effect="fade" time="250">WindowClose</animation>
+      <animation effect="fade" time="250" condition="!control.hasfocus(456852)">conditional</animation>
+    </control>
+
+    <!-- Awards -->
+    <control>
+  	  <description>Awards</description>
+      <type>image</type>
+      <id>0</id>
+   	  <posX>1800</posX>
+      <posY>360</posY>
+      <width>60</width>
+      <height>600</height>
+      <texture>#fanarthandler.movie.awards.selected.verticalall</texture>
+      <align>right</align>
+      <valign>top</valign>
+      <keepaspectratio>yes</keepaspectratio>
+      <visible>!Control.IsVisible(24)+Control.IsVisible(51)</visible>
+      <animation effect="fade" time="250">WindowOpen</animation>
+      <animation effect="fade" time="250">WindowClose</animation>
+      <animation effect="fade" time="250" condition="!control.hasfocus(456852)">conditional</animation>
+    </control>
+
+    <!-- Studios -->
+    <control>
+  	  <description>Studio Logo</description>
+      <type>image</type>
+      <id>0</id>
+   	  <posX>20</posX>
+      <posY>1000</posY>
+      <width>1900</width>
+      <height>65</height>
+      <align>center</align>
+      <valign>middle</valign>
+      <keepaspectratio>yes</keepaspectratio>
+      <shouldCache>true</shouldCache>
+      <texture>#fanarthandler.movie.studios.selected.all</texture>
+	  <visible>control.hasfocus(456852)</visible>
+      <animation effect="fade" time="250">WindowOpen</animation>
+	  <animation effect="fade" time="250">WindowClose</animation>
+      <animation effect="fade" time="250" condition="control.hasfocus(456852)">conditional</animation>
+    </control>
+
+    <!-- CDArt -->
+    <control>
+      <description>Disc Image</description>
+      <type>image</type>
+      <id>0</id>
+      <posX>1550</posX>
+      <posY>330</posY>
+      <width>300</width>
+      <height>300</height>
+      <texture>..\..\..\Thumbs\CDArt\Movies\#(string.trim(#imdbnumber)).png</texture>
+      <keepaspectratio>yes</keepaspectratio>
+      <visible>!Control.IsVisible(24)+!Control.IsVisible(51)+!Control.IsVisible(53)</visible>
+      <animation effect="rotate" time="1000" start="-100" end="0" condition="true">conditional</animation>
+      <animation effect="fade" time="250" start="100" end="50" condition="true">conditional</animation>
+      <animation effect="fade" time="250">WindowOpen</animation>
+      <animation effect="fade" time="250">WindowClose</animation>
+      <animation effect="fade" time="250" condition="!control.hasfocus(456852)">conditional</animation>
+    </control>
+
+    <control>
+      <description>Unwatched Icon</description>
+      <type>image</type>
+      <id>0</id>
+      <posX>68</posX>
+      <posY>306</posY>
+      <width>114</width>
+      <height>114</height>
+      <texture>unwatched_flag_big.png</texture>
+      <visible>string.equals(#iswatched,no)</visible>
+      <animation effect="fade" time="250">WindowOpen</animation>
+      <animation effect="fade" time="250">WindowClose</animation>
+      <animation effect="fade" time="250" condition="!control.hasfocus(456852)">conditional</animation>
+    </control>
+
+    <import>DialogVideoInfo.watchedCount.xml</import>
+    <import>common.overlay.xml</import>
+  </controls>
+</window>

--- a/Common/common.overlay.xml
+++ b/Common/common.overlay.xml
@@ -1,0 +1,743 @@
+<?xml version="1.0" encoding="utf-8" standalone="yes"?>
+<window>
+<controls>
+
+<!-- Dummy -->
+	<control>
+		<description>dummy (visible when music is playing)</description>
+		<type>label</type>
+		<id>3337</id>
+		<posX>2000</posX>
+		<label>#Play.Current.Artist</label>
+		<visible>Player.HasAudio+control.hastext(3337)</visible>
+	</control>
+
+	<control>
+		<description>dummy (visible when there is a next track)</description>
+		<type>label</type>
+		<id>3338</id>
+		<posX>2000</posX>
+		<label>#Play.Next.Title</label>
+		<visible>Player.HasAudio+control.hastext(3338)</visible>
+	</control>
+
+	<control>
+		<description>dummy (visible when tv is running)</description>
+		<type>label</type>
+		<id>3339</id>
+		<posX>2000</posX>
+		<label>#TV.View.channel</label>
+		<visible>Player.HasVideo+!control.hastext(3337)</visible>
+	</control>
+
+<!-- TV/Video -->
+
+    <!-- CD/DVD Disk Logo -->
+
+ 	<control>
+ 		<description>Movie CDArt</description>
+ 		<type>image</type>
+ 		<id>0</id>
+  	    <posX>700</posX>
+	    <posY>70</posY>
+	    <width>200</width>
+	    <height>200</height>
+		<texture>#fanarthandler.movie.cd.selected</texture>
+ 		<keepaspectratio>yes</keepaspectratio>
+ 		<centered>yes</centered>
+   		<align>center</align>
+ 		<zoom>no</zoom>
+ 		<valign>top</valign>
+ 		<visible>player.hasvideo+!control.isvisible(3337)+!string.equals(#Play.Current.IMDBNumber,)</visible>
+        <animation effect="rotate" delay="0" end="-360" time="8000" loop="true" condition="!player.paused">Conditional</animation>
+        <animation effect="rotate" delay="0" end="-360" time="1500" loop="true" reversible="false" condition="player.forwarding">Conditional</animation>
+        <animation effect="rotate" delay="0" end="360" time="500" loop="true" reversible="false" condition="player.rewinding">Conditional</animation>
+        <animation effect="fade" time="300" end="0" reversible="true" condition="player.paused">Conditional</animation>
+		<animation effect="fade" start="0" end="100" time="500" delay="350">WindowOpen</animation>
+		<animation effect="fade" start="100" end="0" time="0" delay="0">WindowClose</animation>
+		<animation effect="fade" time="350">visible</animation>
+		<animation effect="fade" time="0">hidden</animation>
+ 	</control>
+
+ 	<control>
+ 		<description>Series Seasons CDArt</description>
+ 		<type>image</type>
+ 		<id>234832</id>
+  	    <posX>700</posX>
+	    <posY>70</posY>
+	    <width>200</width>
+	    <height>200</height>
+ 		<texture>#TVSeries.Play.CDSeason</texture>
+ 		<keepaspectratio>yes</keepaspectratio>
+ 		<centered>yes</centered>
+   		<align>center</align>
+ 		<zoom>no</zoom>
+ 		<valign>top</valign>
+ 		<visible>player.hasvideo+!control.isvisible(3337)+!string.equals(#TVSeries.Episode.SeriesName,)</visible>
+        <animation effect="rotate" delay="0" end="-360" time="8000" loop="true" condition="!player.paused">Conditional</animation>
+        <animation effect="rotate" delay="0" end="-360" time="1500" loop="true" reversible="false" condition="player.forwarding">Conditional</animation>
+        <animation effect="rotate" delay="0" end="360" time="500" loop="true" reversible="false" condition="player.rewinding">Conditional</animation>
+        <animation effect="fade" time="300" end="0" reversible="true" condition="player.paused">Conditional</animation>
+		<animation effect="fade" start="0" end="100" time="500" delay="350">WindowOpen</animation>
+		<animation effect="fade" start="100" end="0" time="0" delay="0">WindowClose</animation>
+		<animation effect="fade" time="350">visible</animation>
+		<animation effect="fade" time="0">hidden</animation>
+ 	</control>
+
+	<control>
+ 		<description>Series CDArt</description>
+ 		<type>image</type>
+ 		<id>0</id>
+  	    <posX>700</posX>
+	    <posY>70</posY>
+	    <width>200</width>
+	    <height>200</height>
+ 		<texture>#TVSeries.Play.CD</texture>
+ 		<keepaspectratio>yes</keepaspectratio>
+ 		<centered>yes</centered>
+   		<align>center</align>
+ 		<zoom>no</zoom>
+ 		<valign>top</valign>
+ 		<visible>player.hasvideo+!control.isvisible(3337)+!string.equals(#TVSeries.Episode.SeriesName,)+!control.hasthumb(234832)</visible>
+        <animation effect="rotate" delay="0" end="-360" time="8000" loop="true" condition="!player.paused">Conditional</animation>
+        <animation effect="rotate" delay="0" end="-360" time="1500" loop="true" reversible="false" condition="player.forwarding">Conditional</animation>
+        <animation effect="rotate" delay="0" end="360" time="500" loop="true" reversible="false" condition="player.rewinding">Conditional</animation>
+        <animation effect="fade" time="300" end="0" reversible="true" condition="player.paused">Conditional</animation>
+		<animation effect="fade" start="0" end="100" time="500" delay="350">WindowOpen</animation>
+		<animation effect="fade" start="100" end="0" time="0" delay="0">WindowClose</animation>
+		<animation effect="fade" time="350">visible</animation>
+		<animation effect="fade" time="0">hidden</animation>
+ 	</control>
+
+   	<control>
+   		<description>mvCentral CDArt</description>
+   		<type>image</type>
+   		<id>0</id>
+  	    <posX>700</posX>
+	    <posY>70</posY>
+	    <width>200</width>
+	    <height>200</height>
+        <visible>player.hasvideo+string.equals(#mvCentral.isPlaying,true)</visible>
+     	<texture>..\..\..\Thumbs\CDArt\Music\#Play.Current.mvArtist - #Play.Current.mvAlbum.png</texture>
+        <animation effect="rotate" delay="0" end="-360" time="8000" loop="true" condition="!player.paused">Conditional</animation>
+        <animation effect="rotate" delay="0" end="-360" time="1500" loop="true" reversible="false" condition="player.forwarding">Conditional</animation>
+        <animation effect="rotate" delay="0" end="360" time="500" loop="true" reversible="false" condition="player.rewinding">Conditional</animation>
+        <animation effect="fade" time="300" end="0" reversible="true" condition="player.paused">Conditional</animation>
+		<animation effect="fade" start="0" end="100" time="500" delay="350">WindowOpen</animation>
+		<animation effect="fade" start="100" end="0" time="0" delay="0">WindowClose</animation>
+		<animation effect="fade" time="350">visible</animation>
+		<animation effect="fade" time="0">hidden</animation>
+   	</control>  
+
+  <control>
+    <description>now playing background</description>
+    <type>image</type>
+    <id>0</id>
+    <posX>593</posX>
+    <posY>0</posY>
+    <width>734</width>
+    <height>238</height>
+    <texture>now_playing_video_bg.png</texture>
+    <visible>player.hasvideo+!control.isvisible(3337)</visible>
+  </control>
+
+  <control>
+    <description>shadow</description>
+    <type>image</type>
+    <id>0</id>
+    <posX>666</posX>
+    <posY>26</posY>
+    <width>273</width>
+    <height>168</height>
+    <texture>now_playing_video_shadow.png</texture>
+    <visible>player.hasvideo+!control.isvisible(3337)</visible>
+  </control>
+
+	<control>
+		<description>video preview window</description>
+		<type>videowindow</type>
+		<id>99</id>
+		<posX>683</posX>
+		<posY>43</posY>
+		<width>240</width>
+		<height>135</height>
+		<action>18</action>
+		<textureFocus>tv_green_border.png</textureFocus>
+		<visible>player.hasvideo+!control.isvisible(3337)</visible>
+	</control>
+
+	<control>
+		<description>nowplaying label</description>
+		<type>label</type>
+		<id>0</id>
+		<posX>950</posX>
+		<posY>59</posY>
+		<width>240</width>
+		<label>4540</label>
+		<font>TitanLight11</font>
+		<textcolor>393939</textcolor>
+		<visible>player.hasvideo+!control.isvisible(3337)</visible>
+	</control>
+	
+	<control>
+		<description>nowplaying text</description>
+		<type>label</type>
+		<id>0</id>
+		<posX>981</posX>
+		<posY>138</posY>
+		<width>220</width>
+		<label>#currentplaytime#(iif(eq(#duration,''),'',string.format(' / {0}',#duration)))</label>
+		<font>TitanLight11</font>
+		<textcolor>393939</textcolor>
+		<visible>player.hasvideo+!control.isvisible(3337)</visible>
+	</control>
+
+<!--Video-->
+
+	<control>
+		<description>scrolling info label</description>
+		<type>fadelabel</type>
+		<id>0</id>
+		<width>290</width>
+		<posX>951</posX>
+		<posY>87</posY>
+		<font>fontB12</font>
+		<label>#Play.Current.Title</label>
+		<textcolor>393939</textcolor>
+		<visible>player.hasvideo+!control.isvisible(3337)</visible>
+	</control>
+
+	<control>
+		<description>progress bar</description>
+		<type>progress</type>
+		<id>0</id>
+		<posX>938</posX>
+		<posY>128</posY>
+		<width>308</width>
+		<height>8</height>
+		<texturebg>-</texturebg>
+		<lefttexture>now_playing_progress_left.png</lefttexture>
+		<midtexture>now_playing_progress_mid.png</midtexture>
+		<righttexture>now_playing_progress_right.png</righttexture>
+		<label>#percentage</label>
+		<visible>player.hasvideo+!control.isvisible(3337)</visible>
+	</control>
+	
+	<control>
+    <description>play icon</description>
+    <type>image</type>
+    <id>0</id>
+    <posX>951</posX>
+    <posY>143</posY>
+    <width>16</width>
+    <height>19</height>
+    <texture>now_playing_play.png</texture>
+    <keepaspectratio>yes</keepaspectratio>
+    <visible>player.playing+player.hasvideo</visible>
+  </control>
+	
+    <!-- ClearArt -->
+    <control>
+      <description>ClearArt</description>
+      <type>image</type>
+      <id>258456952</id>
+      <posX>1130</posX>
+      <posY>138</posY>
+      <width>100</width>
+      <height>37</height>           
+      <texture>#fanarthandler.music.artistclearart.play</texture>
+      <animation effect="fade" start="0" end="100" time="500" delay="350">WindowOpen</animation>
+      <animation effect="fade" start="100" end="0" time="0" delay="0">WindowClose</animation>
+      <animation effect="fade" time="350">visible</animation>
+      <animation effect="fade" time="0">hidden</animation>
+      <shouldCache>false</shouldCache>
+      <visible>Player.HasVideo+string.equals(#mvCentral.isPlaying,true)</visible>
+      <align>right</align>
+      <valign>top</valign>
+      <keepaspectratio>false</keepaspectratio>
+    </control>
+    <control>
+      <description>ClearArt</description>
+      <type>image</type>
+      <id>0</id>
+      <posX>1130</posX>
+      <posY>138</posY>
+      <width>100</width>
+      <height>37</height>           
+      <texture>..\..\..\Thumbs\ClearArt\Music\#Play.Current.mvArtist.png</texture>
+      <animation effect="fade" start="0" end="100" time="500" delay="350">WindowOpen</animation>
+      <animation effect="fade" start="100" end="0" time="0" delay="0">WindowClose</animation>
+      <animation effect="fade" time="350">visible</animation>
+      <animation effect="fade" time="0">hidden</animation>
+      <shouldCache>false</shouldCache>
+      <visible>Player.HasVideo+!control.hasthumb(258456952)+string.equals(#mvCentral.isPlaying,true)</visible>
+      <align>right</align>
+      <valign>top</valign>
+      <keepaspectratio>yes</keepaspectratio>
+    </control>
+
+<!--Audio-->
+
+	<!-- CDArt -->
+   	<control>
+   		<description>CDArt</description>
+   		<type>image</type>
+   		<id>125521</id>
+  	    <posX>732</posX>
+	    <posY>102</posY>
+	    <width>138</width>
+	    <height>138</height>
+        <visible>player.hasaudio+control.isvisible(3337)</visible>
+     	<texture>#fanarthandler.music.albumcd.play</texture>
+        <animation effect="rotate" delay="0" end="-360" time="8000" loop="true" condition="!player.paused">Conditional</animation>
+        <animation effect="rotate" delay="0" end="-360" time="1500" loop="true" reversible="false" condition="player.forwarding">Conditional</animation>
+        <animation effect="rotate" delay="0" end="360" time="500" loop="true" reversible="false" condition="player.rewinding">Conditional</animation>
+        <animation effect="slide" time="300" end="0,-59" reversible="true" condition="player.paused">Conditional</animation>
+		<animation effect="fade" start="0" end="100" time="500" delay="350">WindowOpen</animation>
+		<animation effect="fade" start="100" end="0" time="0" delay="0">WindowClose</animation>
+		<animation effect="fade" time="350">visible</animation>
+		<animation effect="fade" time="0">hidden</animation>
+   	</control>  
+
+   	<control>
+   		<description>CDArt</description>
+   		<type>image</type>
+   		<id>123321</id>
+  	    <posX>732</posX>
+	    <posY>102</posY>
+	    <width>138</width>
+	    <height>138</height>
+        <visible>player.hasaudio+control.isvisible(3337)+!control.hasthumb(125521)</visible>
+     	<texture>..\..\..\Thumbs\CDArt\Music\#Play.Current.AlbumArtist - #Play.Current.Album.png</texture>
+        <animation effect="rotate" delay="0" end="-360" time="8000" loop="true" condition="!player.paused">Conditional</animation>
+        <animation effect="rotate" delay="0" end="-360" time="1500" loop="true" reversible="false" condition="player.forwarding">Conditional</animation>
+        <animation effect="rotate" delay="0" end="360" time="500" loop="true" reversible="false" condition="player.rewinding">Conditional</animation>
+        <animation effect="slide" time="300" end="0,-59" reversible="true" condition="player.paused">Conditional</animation>
+		<animation effect="fade" start="0" end="100" time="500" delay="350">WindowOpen</animation>
+		<animation effect="fade" start="100" end="0" time="0" delay="0">WindowClose</animation>
+		<animation effect="fade" time="350">visible</animation>
+		<animation effect="fade" time="0">hidden</animation>
+   	</control>  
+
+   	<control>
+   		<description>CDArt</description>
+   		<type>image</type>
+   		<id>0</id>
+  	    <posX>732</posX>
+	    <posY>102</posY>
+	    <width>138</width>
+	    <height>138</height>
+        <visible>player.hasaudio+control.isvisible(3337)+!control.hasthumb(123321)+!control.hasthumb(125521)</visible>
+     	<texture>..\..\..\Thumbs\CDArt\Music\#Play.Current.Artist - #Play.Current.Album.png</texture>
+        <animation effect="rotate" delay="0" end="-360" time="8000" loop="true" condition="!player.paused">Conditional</animation>
+        <animation effect="rotate" delay="0" end="-360" time="1500" loop="true" reversible="false" condition="player.forwarding">Conditional</animation>
+        <animation effect="rotate" delay="0" end="360" time="500" loop="true" reversible="false" condition="player.rewinding">Conditional</animation>
+        <animation effect="slide" time="300" end="0,-59" reversible="true" condition="player.paused">Conditional</animation>
+		<animation effect="fade" start="0" end="100" time="500" delay="350">WindowOpen</animation>
+		<animation effect="fade" start="100" end="0" time="0" delay="0">WindowClose</animation>
+		<animation effect="fade" time="350">visible</animation>
+		<animation effect="fade" time="0">hidden</animation>
+   	</control>  
+
+	<control>
+    <description>now playing background</description>
+    <type>image</type>
+    <id>0</id>
+    <posX>644</posX>
+    <posY>0</posY>
+    <width>633</width>
+    <height>238</height>
+    <texture>now_playing_music_bg.png</texture>
+    <visible>player.hasaudio+control.isvisible(3337)</visible>
+		<animation effect="fade" start="0" end="100" time="300" delay="350">WindowOpen</animation>
+		<animation effect="fade" start="100" end="0" time="0" delay="0">WindowClose</animation>
+		<animation effect="fade" time="250">visible</animation>
+		<animation effect="fade" time="0">hidden</animation>
+  </control>
+
+	<control>
+    <description>shadow</description>
+    <type>image</type>
+    <id>0</id>
+	  <posX>716</posX>
+	  <posY>26</posY>
+    <width>170</width>
+    <height>168</height>
+    <texture>now_playing_music_shadow.png</texture>
+    <visible>player.hasaudio+control.isvisible(3337)</visible>
+	  <animation effect="fade" start="0" end="100" time="300" delay="350">WindowOpen</animation>
+	  <animation effect="fade" start="100" end="0" time="0" delay="0">WindowClose</animation>
+	  <animation effect="fade" time="250">visible</animation>
+	  <animation effect="fade" time="0">hidden</animation>
+  </control>
+
+	<control>
+    <description>album logo</description>
+    <type>image</type>
+    <id>0</id>
+	  <posX>732</posX>
+	  <posY>43</posY>
+	  <width>138</width>
+	  <height>135</height>
+    <texture>#fanarthandler.music.artisthumb.play</texture>
+    <visible>player.hasaudio+control.isvisible(3337)</visible>
+		<animation effect="fade" start="0" end="100" time="300" delay="350">WindowOpen</animation>
+		<animation effect="fade" start="100" end="0" time="0" delay="0">WindowClose</animation>
+		<animation effect="fade" time="250">visible</animation>
+		<animation effect="fade" time="0">hidden</animation>
+  </control>
+	
+	<control>
+    <description>album logo</description>
+    <type>image</type>
+    <id>0</id>
+	  <posX>732</posX>
+	  <posY>43</posY>
+	  <width>138</width>
+	  <height>135</height>
+    <texture>#Play.Current.Thumb</texture>
+    <visible>player.hasaudio+control.isvisible(3337)+string.equals(#fanarthandler.music.artisthumb.play,)</visible>
+		<animation effect="fade" start="0" end="100" time="300" delay="350">WindowOpen</animation>
+		<animation effect="fade" start="100" end="0" time="0" delay="0">WindowClose</animation>
+		<animation effect="fade" time="250">visible</animation>
+		<animation effect="fade" time="0">hidden</animation>
+  </control>
+
+	<control>
+    <description>no album logo</description>
+    <type>image</type>
+    <id>0</id>
+	  <posX>732</posX>
+	  <posY>43</posY>
+	  <width>138</width>
+	  <height>135</height>
+    <texture>audio_nothumb.png</texture>
+    <visible>player.hasaudio+control.isvisible(3337)+string.equals(#Play.Current.Thumb,)+string.equals(#fanarthandler.music.artisthumb.play,)</visible>
+		<animation effect="fade" start="0" end="100" time="300" delay="350">WindowOpen</animation>
+		<animation effect="fade" start="100" end="0" time="0" delay="0">WindowClose</animation>
+		<animation effect="fade" time="250">visible</animation>
+		<animation effect="fade" time="0">hidden</animation>
+  </control>
+
+	<control>
+		<type>fadelabel</type>
+		<description>title label</description>
+		<id>0</id>
+		<posX>898</posX>
+		<posY>87</posY>
+		<width>290</width>
+		<!--label>#Play.Current.Title</label-->
+		<label>#Play.Current.Artist#(iif(eq(#Play.Current.Album,''),'',string.format(' - {0}',#Play.Current.Album)))#(iif(eq(#Play.Current.Title,''),'',string.format(' - {0}',#Play.Current.Title)))</label>
+		<font>fontB12</font>
+		<textcolor>393939</textcolor>
+		<visible>player.hasaudio+control.hastext(3337)</visible>
+		<animation effect="fade" start="0" end="100" time="300" delay="350">WindowOpen</animation>
+		<animation effect="fade" start="100" end="0" time="0" delay="0">WindowClose</animation>
+		<animation effect="fade" time="250">visible</animation>
+		<animation effect="fade" time="0">hidden</animation>
+	</control>
+	
+	<control>
+		<description>nowplaying label</description>
+		<type>label</type>
+		<id>0</id>
+		<posX>898</posX>
+		<posY>53</posY>
+		<width>240</width>
+		<label>4540</label>
+		<font>TitanLight11</font>
+		<textcolor>393939</textcolor>
+		<visible>player.hasaudio+control.isvisible(3337)</visible>
+		<animation effect="fade" start="0" end="100" time="300" delay="350">WindowOpen</animation>
+		<animation effect="fade" start="100" end="0" time="0" delay="0">WindowClose</animation>
+		<animation effect="fade" time="250">visible</animation>
+		<animation effect="fade" time="0">hidden</animation>
+	</control>
+	
+	<control>
+		<description>nowplaying text</description>
+		<type>label</type>
+		<id>0</id>
+		<posX>927</posX>
+		<posY>142</posY>
+		<width>220</width>
+		<label>#currentplaytime#(iif(eq(#duration,''),'',string.format(' / {0}',#duration)))</label>
+		<font>TitanLight11</font>
+		<textcolor>393939</textcolor>
+		<visible>player.hasaudio+control.hastext(3337)</visible>
+		<animation effect="fade" start="0" end="100" time="300" delay="350">WindowOpen</animation>
+		<animation effect="fade" start="100" end="0" time="0" delay="0">WindowClose</animation>
+		<animation effect="fade" time="250">visible</animation>
+		<animation effect="fade" time="0">hidden</animation>
+	</control>
+
+	<control>
+		<description>progress bar</description>
+		<type>progress</type>
+		<id>0</id>
+		<posX>886</posX>
+		<posY>128</posY>
+		<width>308</width>
+		<height>8</height>
+		<texturebg>-</texturebg>
+		<lefttexture>now_playing_progress_left.png</lefttexture>
+		<midtexture>now_playing_progress_mid.png</midtexture>
+		<righttexture>now_playing_progress_right.png</righttexture>
+		<label>#percentage</label>
+		<visible>player.hasmedia+control.hastext(3337)</visible>
+		<animation effect="fade" start="0" end="100" time="300" delay="350">WindowOpen</animation>
+		<animation effect="fade" start="100" end="0" time="0" delay="0">WindowClose</animation>
+		<animation effect="fade" time="250">visible</animation>
+		<animation effect="fade" time="0">hidden</animation>
+	</control>
+    
+	<control>
+		<description>play icon</description>
+		<type>image</type>
+		<id>0</id>
+		<posX>899</posX>
+		<posY>148</posY>
+		<width>16</width>
+		<height>19</height>
+		<texture>now_playing_play.png</texture>
+		<keepaspectratio>yes</keepaspectratio>
+		<visible>player.playing+control.hastext(3337)</visible>
+		<animation effect="fade" start="0" end="100" time="300" delay="350">WindowOpen</animation>
+		<animation effect="fade" start="100" end="0" time="0" delay="0">WindowClose</animation>
+		<animation effect="fade" time="250">visible</animation>
+		<animation effect="fade" time="0">hidden</animation>
+    </control>
+
+	<control>
+		<description>pause icon</description>
+		<type>image</type>
+		<id>0</id>
+		<posX>899</posX>
+		<posY>149</posY>
+		<width>18</width>
+		<height>19</height>
+		<texture>now_playing_pause.png</texture>
+		<keepaspectratio>yes</keepaspectratio>
+		<visible>player.paused+control.hastext(3337)</visible>
+		<animation effect="fade" start="0" end="100" time="300" delay="350">WindowOpen</animation>
+		<animation effect="fade" start="100" end="0" time="0" delay="0">WindowClose</animation>
+		<animation effect="fade" time="250">visible</animation>
+		<animation effect="fade" time="0">hidden</animation>
+    </control>
+
+<!--Radio-->
+
+	<control>
+		<description>now playing background</description>
+		<type>image</type>
+		<id>0</id>
+		<posX>644</posX>
+		<posY>0</posY>
+		<width>633</width>
+		<height>238</height>
+		<texture>now_playing_music_bg.png</texture>
+		<visible>Player.HasAudio+!control.isvisible(3337)+!control.isvisible(3339)</visible>
+		<animation effect="fade" start="0" end="100" time="300" delay="350">WindowOpen</animation>
+		<animation effect="fade" start="100" end="0" time="0" delay="0">WindowClose</animation>
+		<animation effect="fade" time="250">visible</animation>
+		<animation effect="fade" time="0">hidden</animation>
+    </control>
+
+	<control>
+    <description>shadow</description>
+    <type>image</type>
+    <id>0</id>
+	  <posX>716</posX>
+	  <posY>26</posY>
+    <width>170</width>
+    <height>168</height>
+    <texture>now_playing_music_shadow.png</texture>
+    <visible>Player.HasAudio+!control.isvisible(3337)+!control.isvisible(3339)</visible>
+	  <animation effect="fade" start="0" end="100" time="300" delay="350">WindowOpen</animation>
+	  <animation effect="fade" start="100" end="0" time="0" delay="0">WindowClose</animation>
+	  <animation effect="fade" time="250">visible</animation>
+	  <animation effect="fade" time="0">hidden</animation>
+  </control>
+
+	<control>
+		<description>album logo</description>
+		<type>image</type>
+		<id>0</id>
+		<posX>732</posX>
+		<posY>43</posY>
+		<width>138</width>
+		<height>135</height>
+		<texture>#Play.Current.Thumb</texture>
+		<visible>Player.HasAudio+!control.isvisible(3337)+!control.isvisible(3339)</visible>
+		<animation effect="fade" start="0" end="100" time="300" delay="350">WindowOpen</animation>
+		<animation effect="fade" start="100" end="0" time="0" delay="0">WindowClose</animation>
+		<animation effect="fade" time="250">visible</animation>
+		<animation effect="fade" time="0">hidden</animation>
+  </control>
+	
+	<control>
+		<description>no album logo</description>
+		<type>image</type>
+		<id>0</id>
+		<posX>732</posX>
+		<posY>43</posY>
+		<width>138</width>
+		<height>135</height>
+		<texture>audio_nothumb.png</texture>
+		<visible>Player.HasAudio+!control.isvisible(3337)+!control.isvisible(3339)+string.equals(#Play.Current.Thumb,)</visible>
+		<animation effect="fade" start="0" end="100" time="300" delay="350">WindowOpen</animation>
+		<animation effect="fade" start="100" end="0" time="0" delay="0">WindowClose</animation>
+		<animation effect="fade" time="250">visible</animation>
+		<animation effect="fade" time="0">hidden</animation>
+  </control>
+
+	<control>
+		<type>fadelabel</type>
+		<description>title label</description>
+		<id>0</id>
+		<posX>898</posX>
+		<posY>87</posY>
+		<width>290</width>
+		<!--label>#Play.Current.Title</label-->
+		<label>#Play.Current.Artist#(iif(eq(#Play.Current.Album,''),'',string.format(' - {0}',#Play.Current.Album)))#(iif(eq(#Play.Current.Title,''),'',string.format(' - {0}',#Play.Current.Title)))</label>
+		<font>fontB12</font>
+		<textcolor>393939</textcolor>
+		<visible>Player.HasAudio+!control.isvisible(3337)+!control.isvisible(3339)</visible>
+		<animation effect="fade" start="0" end="100" time="300" delay="350">WindowOpen</animation>
+		<animation effect="fade" start="100" end="0" time="0" delay="0">WindowClose</animation>
+		<animation effect="fade" time="250">visible</animation>
+		<animation effect="fade" time="0">hidden</animation>
+	</control>
+	
+	<control>
+		<description>nowplaying label</description>
+		<type>label</type>
+		<id>0</id>
+		<posX>898</posX>
+		<posY>59</posY>
+		<width>240</width>
+		<label>4540</label>
+		<font>TitanLight11</font>
+		<textcolor>393939</textcolor>
+		<visible>Player.HasAudio+!control.isvisible(3337)+!control.isvisible(3339)</visible>
+		<animation effect="fade" start="0" end="100" time="300" delay="350">WindowOpen</animation>
+		<animation effect="fade" start="100" end="0" time="0" delay="0">WindowClose</animation>
+		<animation effect="fade" time="250">visible</animation>
+		<animation effect="fade" time="0">hidden</animation>
+	</control>
+	
+	<control>
+		<description>nowplaying text</description>
+		<type>label</type>
+		<id>0</id>
+		<posX>927</posX>
+		<posY>138</posY>
+		<width>220</width>
+		<label>#currentplaytime#(iif(eq(#duration,''),'',string.format(' / {0}',#duration)))</label>
+		<font>TitanLight11</font>
+		<textcolor>393939</textcolor>
+		<visible>Player.HasAudio+!control.isvisible(3337)+!control.isvisible(3339)</visible>
+		<animation effect="fade" start="0" end="100" time="300" delay="350">WindowOpen</animation>
+		<animation effect="fade" start="100" end="0" time="0" delay="0">WindowClose</animation>
+		<animation effect="fade" time="250">visible</animation>
+		<animation effect="fade" time="0">hidden</animation>
+	</control>
+
+	<control>
+		<description>progress bar</description>
+		<type>progress</type>
+		<id>0</id>
+		<posX>886</posX>
+		<posY>128</posY>
+		<width>308</width>
+		<height>8</height>
+		<texturebg>-</texturebg>
+		<lefttexture>now_playing_progress_left.png</lefttexture>
+		<midtexture>now_playing_progress_mid.png</midtexture>
+		<righttexture>now_playing_progress_right.png</righttexture>
+		<label>#percentage</label>
+		<visible>Player.HasAudio+!control.isvisible(3337)+!control.isvisible(3339)</visible>
+		<animation effect="fade" start="0" end="100" time="300" delay="350">WindowOpen</animation>
+		<animation effect="fade" start="100" end="0" time="0" delay="0">WindowClose</animation>
+		<animation effect="fade" time="250">visible</animation>
+		<animation effect="fade" time="0">hidden</animation>
+	</control>
+    
+	<control>
+		<description>play icon</description>
+		<type>image</type>
+		<id>0</id>
+		<posX>899</posX>
+		<posY>143</posY>
+		<width>16</width>
+		<height>19</height>
+		<texture>now_playing_play.png</texture>
+		<keepaspectratio>yes</keepaspectratio>
+		<visible>Player.HasAudio+!control.isvisible(3337)+!control.isvisible(3339)</visible>
+		<animation effect="fade" start="0" end="100" time="300" delay="350">WindowOpen</animation>
+		<animation effect="fade" start="100" end="0" time="0" delay="0">WindowClose</animation>
+		<animation effect="fade" time="250">visible</animation>
+		<animation effect="fade" time="0">hidden</animation>
+  </control>
+
+    <!-- ClearArt -->
+    <control>
+      <description>ClearArt</description>
+      <type>image</type>
+      <id>258456950</id>
+      <posX>1090</posX>
+      <posY>138</posY>
+      <width>100</width>
+      <height>37</height>           
+      <texture>#fanarthandler.music.artistclearart.play</texture>
+      <animation effect="fade" start="0" end="100" time="500" delay="350">WindowOpen</animation>
+      <animation effect="fade" start="100" end="0" time="0" delay="0">WindowClose</animation>
+      <animation effect="fade" time="350">visible</animation>
+      <animation effect="fade" time="0">hidden</animation>
+      <shouldCache>false</shouldCache>
+      <visible>Player.HasAudio</visible>
+      <align>right</align>
+      <valign>top</valign>
+      <keepaspectratio>false</keepaspectratio>
+    </control>
+    <control>
+      <description>ClearArt</description>
+      <type>image</type>
+      <id>258456951</id>
+      <posX>1090</posX>
+      <posY>138</posY>
+      <width>100</width>
+      <height>37</height>           
+      <texture>..\..\..\Thumbs\ClearArt\Music\#Play.Current.Artist.png</texture>
+      <animation effect="fade" start="0" end="100" time="500" delay="350">WindowOpen</animation>
+      <animation effect="fade" start="100" end="0" time="0" delay="0">WindowClose</animation>
+      <animation effect="fade" time="350">visible</animation>
+      <animation effect="fade" time="0">hidden</animation>
+      <shouldCache>false</shouldCache>
+      <visible>Player.HasAudio+!control.hasthumb(258456950)</visible>
+      <align>right</align>
+      <valign>top</valign>
+      <keepaspectratio>yes</keepaspectratio>
+    </control>
+    <control>
+      <description>ClearArt</description>
+      <type>image</type>
+      <id>0</id>
+      <posX>1090</posX>
+      <posY>138</posY>
+      <width>100</width>
+      <height>37</height>           
+      <texture>..\..\..\Thumbs\ClearArt\Music\#Play.Current.AlbumArtist.png</texture>
+      <animation effect="fade" start="0" end="100" time="500" delay="350">WindowOpen</animation>
+      <animation effect="fade" start="100" end="0" time="0" delay="0">WindowClose</animation>
+      <animation effect="fade" time="350">visible</animation>
+      <animation effect="fade" time="0">hidden</animation>
+      <visible>Player.HasAudio+!control.hasthumb(258456950)+!control.hasthumb(258456951)</visible>
+      <shouldCache>false</shouldCache>
+      <align>right</align>
+      <valign>top</valign>
+      <keepaspectratio>yes</keepaspectratio>
+    </control>
+
+</controls>
+</window>

--- a/Common/dialogGeneralRating.xml
+++ b/Common/dialogGeneralRating.xml
@@ -1,0 +1,81 @@
+<?xml version="1.0" encoding="utf-8" standalone="yes"?>
+<window>
+  <id>28380</id>
+  <defaultcontrol>10</defaultcontrol>
+  <allowoverlay>yes</allowoverlay>
+  <controls>
+    <import>common.dialog.xml</import>
+    <control>
+      <description>group element</description>
+      <type>group</type>
+      <animation effect="fade" time="250">WindowOpen</animation>
+      <animation effect="fade" time="0">WindowClose</animation>
+      <animation effect="slide" start="0,200" end="0,0" tween="quadratic" easing="in" time="150" delay="0">WindowOpen</animation>
+      <control>
+        <description>1 Star</description>
+        <type>checkmark</type>
+        <id>100</id>
+        <posX>830</posX>
+        <posY>766</posY>
+        <width>53</width>
+        <height>41</height>
+        <textureCheckmark>starblue_rating.png</textureCheckmark>
+        <textureCheckmarkNoFocus>starblack_rating.png</textureCheckmarkNoFocus>
+      </control>
+      <control>
+        <description>2 Star</description>
+        <type>checkmark</type>
+        <id>101</id>
+        <posX>880</posX>
+        <posY>766</posY>
+        <width>53</width>
+        <height>41</height>
+        <textureCheckmark>starblue_rating.png</textureCheckmark>
+        <textureCheckmarkNoFocus>starblack_rating.png</textureCheckmarkNoFocus>
+      </control>
+      <control>
+        <description>3 Star</description>
+        <type>checkmark</type>
+        <id>102</id>
+        <posX>930</posX>
+        <posY>766</posY>
+        <width>53</width>
+        <height>41</height>
+        <textureCheckmark>starblue_rating.png</textureCheckmark>
+        <textureCheckmarkNoFocus>starblack_rating.png</textureCheckmarkNoFocus>
+      </control>
+      <control>
+        <description>4 Star</description>
+        <type>checkmark</type>
+        <id>103</id>
+        <posX>980</posX>
+        <posY>766</posY>
+        <width>53</width>
+        <height>41</height>
+        <textureCheckmark>starblue_rating.png</textureCheckmark>
+        <textureCheckmarkNoFocus>starblack_rating.png</textureCheckmarkNoFocus>
+      </control>
+      <control>
+        <description>5 Star</description>
+        <type>checkmark</type>
+        <id>104</id>
+        <posX>1030</posX>
+        <posY>766</posY>
+        <width>53</width>
+        <height>41</height>
+        <textureCheckmark>starblue_rating.png</textureCheckmark>
+        <textureCheckmarkNoFocus>starblack_rating.png</textureCheckmarkNoFocus>
+      </control>
+      <control>
+        <id>7</id>
+        <description>Selected Rating</description>
+        <type>label</type>
+        <posX>575</posX>
+        <posY>866</posY>
+        <width>768</width>
+        <align>center</align>
+        <textcolor>ff393939</textcolor>
+      </control>
+    </control>
+  </controls>
+</window>

--- a/Common/movingpictures.mediainfo.details.xml
+++ b/Common/movingpictures.mediainfo.details.xml
@@ -61,7 +61,7 @@
       <description>Aspect ratio</description>
       <type>image</type>
       <id>0</id>
-      <posX>1433</posX>
+      <posX>1453</posX>
       <posY>862</posY>
       <width>92</width>
       <height>60</height>

--- a/Common/movingpictures.mediainfo.xml
+++ b/Common/movingpictures.mediainfo.xml
@@ -62,7 +62,7 @@
   	<description>Aspect ratio</description>
     <type>image</type>
     <id>0</id>
-		<posX>975</posX>
+		<posX>995</posX>
 		<posY>890</posY>
     <width>92</width>
     <height>60</height>
@@ -146,7 +146,7 @@
   	<description>Aspect ratio</description>
     <type>image</type>
     <id>0</id>
-   	<posX>526</posX>
+   	<posX>546</posX>
     <posY>880</posY>
     <width>92</width>
     <height>60</height>

--- a/Common/myvideo.mediainfo.xml
+++ b/Common/myvideo.mediainfo.xml
@@ -1,0 +1,190 @@
+<?xml version="1.0" encoding="utf-8" standalone="yes"?>
+<window>
+<controls>
+	
+  <!--            :: LISTVIEW ::            -->
+	
+  <control>
+  	<description>Certification (MPAA) Logo</description>
+    <type>image</type>
+    <id>0</id>
+    <posX>588</posX>
+    <posY>893</posY>
+    <width>50</width>
+    <height>50</height>
+    <texture>certification\#mpaarating.png</texture>
+    <keepaspectratio>yes</keepaspectratio>
+ 		<visible>[facadeview.list|facadeview.playlist]+Control.IsVisible(50)</visible>
+	  <animation effect="fade" time="250">WindowOpen</animation>
+	  <animation effect="fade" time="250">WindowClose</animation>
+  </control>
+  
+ 	<control>
+  	<description>Video resolution</description>
+    <type>image</type>
+    <id>0</id>
+		<posX>670</posX>
+		<posY>886</posY>
+    <width>99</width>
+    <height>65</height>
+    <texture>Logos\resolution\#VideoResolution.png</texture>
+    <keepaspectratio>yes</keepaspectratio>
+ 		<visible>[facadeview.list|facadeview.playlist]+Control.IsVisible(50)</visible>
+	  <animation effect="fade" time="250">WindowOpen</animation>
+	  <animation effect="fade" time="250">WindowClose</animation>
+  </control>
+  
+  <control>
+  	<description>Video codec</description>
+    <type>image</type>
+    <id>0</id>
+		<posX>750</posX>
+		<posY>886</posY>
+    <width>99</width>
+    <height>65</height>
+    <texture>Logos\video\#VideoCodec.png</texture>
+    <keepaspectratio>yes</keepaspectratio>
+ 		<visible>[facadeview.list|facadeview.playlist]+Control.IsVisible(50)</visible>
+	  <animation effect="fade" time="250">WindowOpen</animation>
+	  <animation effect="fade" time="250">WindowClose</animation>
+  </control>
+
+ 	<control>
+  	<description>Audio codec</description>
+    <type>image</type>
+    <id>0</id>
+		<posX>850</posX>
+		<posY>886</posY>
+    <width>99</width>
+    <height>65</height>
+    <texture>Logos\audio\#AudioCodec.png</texture>
+    <keepaspectratio>yes</keepaspectratio>
+ 		<visible>[facadeview.list|facadeview.playlist]+Control.IsVisible(50)</visible>
+	  <animation effect="fade" time="250">WindowOpen</animation>
+	  <animation effect="fade" time="250">WindowClose</animation>
+  </control>
+  
+	<control>
+  	<description>Audio channels</description>
+    <type>image</type>
+    <id>0</id>
+		<posX>955</posX>
+		<posY>886</posY>
+    <width>99</width>
+    <height>65</height>
+    <texture>Logos\audio\#AudioChannels.png</texture>
+    <keepaspectratio>yes</keepaspectratio>
+ 		<visible>[facadeview.list|facadeview.playlist]+Control.IsVisible(50)</visible>
+	  <animation effect="fade" time="250">WindowOpen</animation>
+	  <animation effect="fade" time="250">WindowClose</animation>
+  </control>
+  
+	<control>
+  	<description>Aspect ratio</description>
+    <type>image</type>
+    <id>0</id>
+		<posX>1050</posX>
+		<posY>886</posY>
+    <width>99</width>
+    <height>65</height>
+    <texture>Logos\aspectratio\#AspectRatio.png</texture>
+    <keepaspectratio>yes</keepaspectratio>
+ 		<visible>[facadeview.list|facadeview.playlist]+Control.IsVisible(50)</visible>
+	  <animation effect="fade" time="250">WindowOpen</animation>
+	  <animation effect="fade" time="250">WindowClose</animation>
+  </control>
+  
+  <!--            :: THUMBVIEW ::            -->
+	
+  <control>
+  	<description>Certification (MPAA) Logo</description>
+    <type>image</type>
+    <id>0</id>
+    <posX>137</posX>
+    <posY>887</posY>
+    <width>50</width>
+    <height>50</height>
+    <texture>certification\#mpaarating.png</texture>
+    <keepaspectratio>yes</keepaspectratio>
+ 		<visible>[facadeview.smallicons | facadeview.largeicons]+Control.IsVisible(50)</visible>
+	  <animation effect="fade" time="250">WindowOpen</animation>
+	  <animation effect="fade" time="250">WindowClose</animation>
+  </control>
+  
+ 	<control>
+  	<description>Video resolution</description>
+    <type>image</type>
+    <id>0</id>
+    <posX>219</posX>
+    <posY>880</posY>
+    <width>99</width>
+    <height>65</height>
+    <texture>Logos\resolution\#VideoResolution.png</texture>
+    <keepaspectratio>yes</keepaspectratio>
+ 		<visible>[facadeview.smallicons | facadeview.largeicons]+Control.IsVisible(50)</visible>
+	  <animation effect="fade" time="250">WindowOpen</animation>
+	  <animation effect="fade" time="250">WindowClose</animation>
+  </control>
+  
+  <control>
+  	<description>Video codec</description>
+    <type>image</type>
+    <id>0</id>
+    <posX>299</posX>
+    <posY>880</posY>
+    <width>99</width>
+    <height>65</height>
+    <texture>Logos\video\#VideoCodec.png</texture>
+    <keepaspectratio>yes</keepaspectratio>
+ 		<visible>[facadeview.smallicons | facadeview.largeicons]+Control.IsVisible(50)</visible>
+	  <animation effect="fade" time="250">WindowOpen</animation>
+	  <animation effect="fade" time="250">WindowClose</animation>
+  </control>
+
+ 	<control>
+  	<description>Audio codec</description>
+    <type>image</type>
+    <id>0</id>
+   	<posX>399</posX>
+    <posY>880</posY>
+    <width>99</width>
+    <height>65</height>
+    <texture>Logos\audio\#AudioCodec.png</texture>
+    <keepaspectratio>yes</keepaspectratio>
+ 		<visible>[facadeview.smallicons | facadeview.largeicons]+Control.IsVisible(50)</visible>
+	  <animation effect="fade" time="250">WindowOpen</animation>
+	  <animation effect="fade" time="250">WindowClose</animation>
+  </control>
+  
+	<control>
+  	<description>Audio channels</description>
+    <type>image</type>
+    <id>0</id>
+   	<posX>504</posX>
+    <posY>880</posY>
+    <width>99</width>
+    <height>65</height>
+    <texture>Logos\audio\#AudioChannels.png</texture>
+    <keepaspectratio>yes</keepaspectratio>
+ 		<visible>[facadeview.smallicons | facadeview.largeicons]+Control.IsVisible(50)</visible>
+	  <animation effect="fade" time="250">WindowOpen</animation>
+	  <animation effect="fade" time="250">WindowClose</animation>
+  </control>
+  
+	<control>
+  	<description>Aspect ratio</description>
+    <type>image</type>
+    <id>0</id>
+   	<posX>599</posX>
+    <posY>880</posY>
+    <width>99</width>
+    <height>65</height>
+    <texture>Logos\aspectratio\#AspectRatio.png</texture>
+    <keepaspectratio>yes</keepaspectratio>
+ 		<visible>[facadeview.smallicons | facadeview.largeicons]+Control.IsVisible(50)</visible>
+	  <animation effect="fade" time="250">WindowOpen</animation>
+	  <animation effect="fade" time="250">WindowClose</animation>
+  </control>
+  
+</controls>
+</window>

--- a/Common/videoFullScreen.xml
+++ b/Common/videoFullScreen.xml
@@ -1,0 +1,610 @@
+<?xml version="1.0" encoding="utf-8" standalone="yes"?>
+<window>
+  <id>2005</id>
+  <defaultcontrol>995</defaultcontrol>
+  <allowoverlay>no</allowoverlay>
+  <controls>
+
+    <control>
+      <description>background image (not used!)</description>
+      <type>button</type>
+      <id>995</id>
+      <posX>2180</posX>
+      <posY>628</posY>
+      <width>20</width>
+      <height>20</height>
+      <onup>995</onup>
+      <ondown>995</ondown>
+      <onleft>995</onleft>
+      <onright>995</onright>
+    </control>
+
+    <control>
+      <description>background image (not used!)</description>
+      <type>image</type>
+      <id>105</id>
+      <posX>2180</posX>
+      <posY>628</posY>
+      <width>1000</width>
+      <height>89</height>
+      <texture>blue.png</texture>
+      <visible>window.ispauseosdvisible|player.rewinding|player.forwarding</visible>
+    </control>
+
+    <!-- Clear Art/Logo -->
+
+    <control>
+      <description>DUMMY CONTROL FOR ClearArt/Logo VISIBILITY CONDITION</description>
+      <type>label</type>
+      <id>456852159</id>
+      <posX>0</posX>
+      <posY>0</posY>
+      <width>1</width>
+      <visible>!window.isosdvisible+window.ispauseosdvisible+player.paused|player.rewinding|player.forwarding|control.isVisible(10)|control.isVisible(11)|control.isVisible(12)</visible>
+    </control>
+
+    <control>
+      <description>Series ClearArt</description>
+      <type>image</type>
+      <id>753951</id>
+      <posX>1430</posX>
+      <posY>720</posY>
+      <width>250</width>
+      <height>140</height>
+      <texture>#fanarthandler.tvseries.clearart.selected</texture>
+      <keepaspectratio>yes</keepaspectratio>
+      <centered>yes</centered>
+      <align>center</align>
+      <zoom>no</zoom>
+      <valign>top</valign>
+      <visible>!string.equals(#TVSeries.Episode.SeriesName,)+control.isVisible(456852159)</visible>
+      <animation effect="fade" time="250">WindowOpen</animation>
+      <animation effect="fade" time="500">VisibleChange</animation>
+    </control>
+
+    <control>
+      <description>Series ClearLogo</description>
+      <type>image</type>
+      <id>0</id>
+      <posX>1430</posX>
+      <posY>720</posY>
+      <width>250</width>
+      <height>140</height>
+      <texture>#fanarthandler.tvseries.clearlogo.selected</texture>
+      <keepaspectratio>yes</keepaspectratio>
+      <centered>yes</centered>
+      <align>center</align>
+      <zoom>no</zoom>
+      <valign>top</valign>
+      <visible>!string.equals(#TVSeries.Episode.SeriesName,)+!control.hasthumb(753951)+control.isVisible(456852159)</visible>
+      <animation effect="fade" time="250">WindowOpen</animation>
+      <animation effect="fade" time="500">VisibleChange</animation>
+    </control>
+
+    <control>
+      <description>Movie ClearArt</description>
+      <type>image</type>
+      <id>159357</id>
+      <posX>1430</posX>
+      <posY>720</posY>
+      <width>250</width>
+      <height>140</height>
+      <texture>#fanarthandler.movie.clearart.selected</texture>
+      <keepaspectratio>yes</keepaspectratio>
+      <centered>yes</centered>
+      <align>center</align>
+      <zoom>no</zoom>
+      <valign>top</valign>
+      <visible>!string.equals(#Play.Current.IMDBNumber,)+control.isVisible(456852159)</visible>
+      <animation effect="fade" time="250">WindowOpen</animation>
+      <animation effect="fade" time="500">VisibleChange</animation>
+    </control>
+
+    <control>
+      <description>Movie ClearLogo</description>
+      <type>image</type>
+      <id>0</id>
+      <posX>1430</posX>
+      <posY>720</posY>
+      <width>250</width>
+      <height>140</height>
+      <texture>#fanarthandler.movie.clearlogo.selected</texture>
+      <keepaspectratio>yes</keepaspectratio>
+      <centered>yes</centered>
+      <align>center</align>
+      <zoom>no</zoom>
+      <valign>top</valign>
+      <visible>!string.equals(#Play.Current.IMDBNumber,)+!control.hasthumb(159357)+control.isVisible(456852159)</visible>
+      <animation effect="fade" time="250">WindowOpen</animation>
+      <animation effect="fade" time="500">VisibleChange</animation>
+    </control>
+
+    <control>
+      <description>mvCentral ClearArt</description>
+      <type>image</type>
+      <id>456852</id>
+      <posX>1455</posX>
+      <posY>760</posY>
+      <width>200</width>
+      <height>75</height>
+      <texture>..\..\..\Thumbs\ClearArt\Music\#Play.Current.mvArtist.png</texture>
+      <keepaspectratio>yes</keepaspectratio>
+      <centered>yes</centered>
+      <align>center</align>
+      <zoom>no</zoom>
+      <valign>top</valign>
+      <visible>!string.equals(#Play.Current.mvArtist,)+control.isVisible(456852159)</visible>
+      <animation effect="fade" time="250">WindowOpen</animation>
+      <animation effect="fade" time="500">VisibleChange</animation>
+    </control>
+
+    <control>
+      <description>Music ClearArt</description>
+      <type>image</type>
+      <id>456852</id>
+      <posX>1455</posX>
+      <posY>760</posY>
+      <width>200</width>
+      <height>75</height>
+      <texture>#fanarthandler.music.artistclearart.play</texture>
+      <keepaspectratio>yes</keepaspectratio>
+      <centered>yes</centered>
+      <align>center</align>
+      <zoom>no</zoom>
+      <valign>bottom</valign>
+      <visible>!control.hasthumb(357951)+!string.equals(#Play.Current.mvArtist,)+control.isVisible(456852159)</visible>
+      <animation effect="fade" time="250">WindowOpen</animation>
+      <animation effect="fade" time="500">VisibleChange</animation>
+    </control>
+
+    <!-- -->
+
+    <control>
+      <description>background image when pause, forward, rewind</description>
+      <type>image</type>
+      <id>111</id>
+      <posX>183</posX>
+      <posY>820</posY>
+      <width>1553</width>
+      <height>238</height>
+      <texture>osd_pause_bg.png</texture>
+      <visible>!window.isosdvisible+window.ispauseosdvisible+player.paused|player.rewinding|player.forwarding|control.isVisible(10)|control.isVisible(11)|control.isVisible(12)</visible>
+    </control>
+
+    <control>
+      <type>label</type>
+      <id>1</id>
+      <description>Clock</description>
+      <posX>272</posX>
+      <posY>916</posY>
+      <width>144</width>
+      <font>TitanLight12</font>
+      <align>center</align>
+      <label>#time</label>
+      <textcolor>ff00b7ff</textcolor>
+      <visible>!window.isosdvisible+window.ispauseosdvisible+player.paused|player.rewinding|player.forwarding|control.isVisible(10)|control.isVisible(11)|control.isVisible(12)</visible>
+    </control>
+
+    <control>
+      <description>clock bg</description>
+      <type>image</type>
+      <id>0</id>
+      <posX>252</posX>
+      <posY>888</posY>
+      <width>184</width>
+      <height>49</height>
+      <texture>osd_clock_pause_bg.png</texture>
+      <visible>!window.isosdvisible+window.ispauseosdvisible+player.paused|player.rewinding|player.forwarding|control.isVisible(10)|control.isVisible(11)|control.isVisible(12)</visible>
+    </control>
+
+    <control>
+      <description>pause button</description>
+      <type>image</type>
+      <id>1</id>
+      <posX>1482</posX>
+      <posY>888</posY>
+      <width>184</width>
+      <height>49</height>
+      <texture>osd_play_button.png</texture>
+      <visible>!window.isosdvisible+window.ispauseosdvisible+player.paused|player.rewinding|player.forwarding|control.isVisible(10)|control.isVisible(11)|control.isVisible(12)</visible>
+    </control>
+
+    <control>
+      <description>pause button</description>
+      <type>image</type>
+      <id>1</id>
+      <posX>856</posX>
+      <posY>295</posY>
+      <width>209</width>
+      <height>221</height>
+      <texture>osd_pause.png</texture>
+      <visible>!window.isosdvisible+window.ispauseosdvisible+player.paused</visible>
+      <animation effect="fade" time="500">VisibleChange</animation>
+    </control>
+
+    <control>
+      <description>progressbar bg</description>
+      <type>image</type>
+      <id>0</id>
+      <posX>588</posX>
+      <posY>907</posY>
+      <width>737</width>
+      <height>18</height>
+      <texture>osd_progress_bg.png</texture>
+      <visible>control.isVisible(111)|control.isVisible(10)|control.isVisible(11)|control.isVisible(12)</visible>
+    </control>
+
+    <control>
+      <description>Remaining time</description>
+      <type>label</type>
+      <id>102</id>
+      <posX>1435</posX>
+      <posY>899</posY>
+      <label>#currentremaining</label>
+      <textcolor>ff00b7ff</textcolor>
+      <align>right</align>
+      <font>font11</font>
+      <visible>control.isVisible(111)|control.isVisible(10)|control.isVisible(11)|control.isVisible(12)</visible>
+    </control>
+
+    <control>
+      <description>Start Time Info</description>
+      <type>label</type>
+      <id>101</id>
+      <posX>484</posX>
+      <posY>899</posY>
+      <label>#currentplaytime</label>
+      <textcolor>ff00b7ff</textcolor>
+      <align>left</align>
+      <font>font11</font>
+      <visible>control.isVisible(111)|control.isVisible(10)|control.isVisible(11)|control.isVisible(12)</visible>
+    </control>
+
+    <control>
+      <description>Title Info</description>
+      <type>fadelabel</type>
+      <id>0</id>
+      <posX>240</posX>
+      <posY>990</posY>
+      <width>1450</width>
+      <label>#Play.Current.Title#(iif(eq(#Play.Current.Year,''),'',' (#Play.Current.Year)'))</label>
+      <textcolor>ff000000</textcolor>
+      <align>center</align>
+      <font>fontB14</font>
+      <wrapString> | </wrapString>
+      <visible>!string.equals(#mvCentral.isPlaying,true)+control.isVisible(111)+!control.isVisible(10)+!control.isVisible(11)+!control.isVisible(12)+!Player.Forwarding+!Player.Rewinding</visible>
+    </control>
+
+    <control>
+      <description>mvCentral Title Info</description>
+      <type>fadelabel</type>
+      <id>0</id>
+      <posX>240</posX>
+      <posY>990</posY>
+      <width>1450</width>
+      <label>#(iif(eq(#Play.Current.mvArtist,''),'',string.format('{0} - ',#Play.Current.mvArtist)))#(iif(eq(#Play.Current.mvAlbum,''),'',string.format('{0} - ',#Play.Current.mvAlbum)))#Play.Current.Title#(iif(eq(#Play.Current.Year,''),'',' (#Play.Current.Year)'))</label>
+      <textcolor>ff000000</textcolor>
+      <align>center</align>
+      <font>fontB14</font>
+      <wrapString> | </wrapString>
+      <visible>string.equals(#mvCentral.isPlaying,true)+control.isVisible(111)+![control.isVisible(10)|control.isVisible(11)|control.isVisible(12)]</visible>
+    </control>
+
+    <control>
+      <description>row 1 label</description>
+      <type>label</type>
+      <id>10</id>
+      <posX>738</posX>
+      <posY>993</posY>
+      <width>444</width>
+      <font>fontB14</font>
+      <align>center</align>
+      <textcolor>ff393939</textcolor>
+      <label>-</label>
+    </control>
+
+    <control>
+      <description>row 2 label</description>
+      <type>label</type>
+      <id>11</id>
+      <posX>738</posX>
+      <posY>993</posY>
+      <width>444</width>
+      <font>fontB14</font>
+      <align>center</align>
+      <textcolor>ff393939</textcolor>
+      <label>-</label>
+    </control>
+
+    <control>
+      <description>row 3 label</description>
+      <type>label</type>
+      <id>12</id>
+      <posX>738</posX>
+      <posY>993</posY>
+      <width>444</width>
+      <font>fontB14</font>
+      <align>center</align>
+      <textcolor>ff393939</textcolor>
+      <label>-</label>
+    </control>
+
+    <control>
+      <description>pause image</description>
+      <type>image</type>
+      <id>16</id>
+      <posX>1157</posX>
+      <posY>18</posY>
+      <width>48</width>
+      <height>48</height>
+      <visible>no</visible>
+      <texture>osd_pause.png</texture>
+    </control>
+
+    <control>
+      <description>2x image</description>
+      <type>image</type>
+      <id>17</id>
+      <posX>898</posX>
+      <posY>978</posY>
+      <width>111</width>
+      <height>26</height>
+      <visible>no</visible>
+      <texture>video+2x.png</texture>
+    </control>
+
+    <control>
+      <description>4x image</description>
+      <type>image</type>
+      <id>18</id>
+      <posX>898</posX>
+      <posY>978</posY>
+      <width>111</width>
+      <height>26</height>
+      <visible>no</visible>
+      <texture>video+4x.png</texture>
+    </control>
+
+    <control>
+      <description>8x image</description>
+      <type>image</type>
+      <id>19</id>
+      <posX>898</posX>
+      <posY>978</posY>
+      <width>111</width>
+      <height>26</height>
+      <visible>no</visible>
+      <texture>video+8x.png</texture>
+    </control>
+
+    <control>
+      <description>16x image</description>
+      <type>image</type>
+      <id>20</id>
+      <posX>898</posX>
+      <posY>978</posY>
+      <width>111</width>
+      <height>26</height>
+      <visible>no</visible>
+      <texture>video+16x.png</texture>
+    </control>
+
+    <control>
+      <description>32x image</description>
+      <type>image</type>
+      <id>21</id>
+      <posX>898</posX>
+      <posY>978</posY>
+      <width>111</width>
+      <height>26</height>
+      <visible>no</visible>
+      <texture>video+32x.png</texture>
+    </control>
+
+    <control>
+      <description>- 2x image</description>
+      <type>image</type>
+      <id>23</id>
+      <posX>898</posX>
+      <posY>978</posY>
+      <width>111</width>
+      <height>26</height>
+      <visible>no</visible>
+      <texture>video-2x.png</texture>
+    </control>
+
+    <control>
+      <description>- 4x image</description>
+      <type>image</type>
+      <id>24</id>
+      <posX>898</posX>
+      <posY>978</posY>
+      <width>111</width>
+      <height>26</height>
+      <visible>no</visible>
+      <texture>video-4x.png</texture>
+    </control>
+
+    <control>
+      <description>- 8x image</description>
+      <type>image</type>
+      <id>25</id>
+      <posX>898</posX>
+      <posY>978</posY>
+      <width>111</width>
+      <height>26</height>
+      <visible>no</visible>
+      <texture>video-8x.png</texture>
+    </control>
+
+    <control>
+      <description>- 16x image</description>
+      <type>image</type>
+      <id>26</id>
+      <posX>898</posX>
+      <posY>978</posY>
+      <width>111</width>
+      <height>26</height>
+      <visible>no</visible>
+      <texture>video-16x.png</texture>
+    </control>
+
+    <control>
+      <description>- 32x image</description>
+      <type>image</type>
+      <id>27</id>
+      <posX>898</posX>
+      <posY>978</posY>
+      <width>111</width>
+      <height>26</height>
+      <visible>no</visible>
+      <texture>video-32x.png</texture>
+    </control>
+
+    <control>
+      <type>image</type>
+      <id>500</id>
+      <posX>898</posX>
+      <posY>978</posY>
+      <width>32</width>
+      <height>32</height>
+      <texture>osdaudiomutenf.png</texture>
+      <colordiffuse>White</colordiffuse>
+      <visible>no</visible>
+    </control>
+
+    <control>
+      <type>volumebar</type>
+      <id>501</id>
+      <posX>1062</posX>
+      <posY>60</posY>
+      <align>right</align>
+      <height>13</height>
+      <imageHeight>3</imageHeight>
+      <texture>volume.states.png</texture>
+      <colordiffuse>White</colordiffuse>
+      <visible>no</visible>
+    </control>
+
+    <import>mvCentral.PlayStart.xml</import>
+
+    <control>
+      <type>image</type>
+      <id>502</id>
+      <posX>1110</posX>
+      <posY>18</posY>
+      <width>48</width>
+      <height>48</height>
+      <texture>video.action.forbidden.png</texture>
+      <colordiffuse>White</colordiffuse>
+      <visible>no</visible>
+    </control>
+
+    <control>
+      <description>Progress Bar</description>
+      <type>progress</type>
+      <id>1</id>
+      <posX>578</posX>
+      <posY>909</posY>
+      <width>758</width>
+      <height>15</height>
+      <label>#percentage</label>
+      <texturebg>-</texturebg>
+      <lefttexture>osd_progress_left.png</lefttexture>
+      <midtexture>osd_progress_mid.png</midtexture>
+      <righttexture>osd_progress_right.png</righttexture>
+      <label>#percentage</label>
+      <visible>control.isVisible(111)|control.isVisible(10)|control.isVisible(11)|control.isVisible(12)</visible>
+    </control>
+
+    <control>
+      <description>Progress Bar</description>
+      <type>tvprogress</type>
+      <id>1</id>
+      <posX>590</posX>
+      <posY>909</posY>
+      <width>730</width>
+      <height>13</height>
+      <toptexture>-</toptexture>
+      <TextureOffsetY>0</TextureOffsetY>
+      <bottomtexture>-</bottomtexture>
+      <texturetick>-</texturetick>
+      <lefttexture>osd_progress_left.png</lefttexture>
+      <midtexture>-</midtexture>
+      <righttexture></righttexture>
+      <logotexture>-</logotexture>
+      <fillbackgroundtexture>-</fillbackgroundtexture>
+      <fillbgxoff>-3</fillbgxoff>
+      <fillbgyoff>0</fillbgyoff>
+      <filltexture1>osd_progress_mid.png</filltexture1>
+      <filltexture2>osd_progress_mid.png</filltexture2>
+      <filltexture3>osd_progress_mid_orange.png</filltexture3>
+      <markertexture>osd_progress_comskip_marker.png</markertexture>
+      <fillheight>15</fillheight>
+      <label>#percentage</label>
+      <labelmarkerstarts>#jumppoints</labelmarkerstarts>
+      <labelmarkerends>#chapters</labelmarkerends>
+      <visible>control.isVisible(111)</visible>
+    </control>
+
+    <!-- Start Play -->
+    
+    <control>
+      <description>Series ClearArt</description>
+      <type>image</type>
+      <id>0</id>
+      <posX>10</posX>
+      <posY>930</posY>
+      <width>250</width>
+      <height>140</height>
+      <texture>#fanarthandler.tvseries.clearart.selected</texture>
+      <keepaspectratio>yes</keepaspectratio>
+      <centered>yes</centered>
+      <align>center</align>
+      <zoom>no</zoom>
+      <valign>top</valign>
+      <visible>!string.equals(#TVSeries.Episode.SeriesName,)+!control.isVisible(456852159)</visible>
+      <animation effect="fade" delay="0" start="0" end="100" time="2000">WindowOpen</animation>
+      <animation effect="fade" delay="5000" start="100" end="0" time="2000" condition="true">conditional</animation>
+    </control>
+    
+    <control>
+      <description>Movie ClearArt</description>
+      <type>image</type>
+      <id>0</id>
+      <posX>10</posX>
+      <posY>930</posY>
+      <width>250</width>
+      <height>140</height>
+      <texture>#fanarthandler.movie.clearart.selected</texture>
+      <keepaspectratio>yes</keepaspectratio>
+      <centered>yes</centered>
+      <align>center</align>
+      <zoom>no</zoom>
+      <valign>top</valign>
+      <visible>!string.equals(#Play.Current.IMDBNumber,)+!control.isVisible(456852159)</visible>
+      <animation effect="fade" delay="0" start="0" end="100" time="2000">WindowOpen</animation>
+      <animation effect="fade" delay="5000" start="100" end="0" time="2000" condition="true">conditional</animation>
+    </control>
+    
+    <control>
+      <description>mvCentral ClearArt</description>
+      <type>image</type>
+      <id>0</id>
+      <posX>10</posX>
+      <posY>930</posY>
+      <width>200</width>
+      <height>75</height>
+      <texture>..\..\..\Thumbs\ClearArt\Music\#Play.Current.mvArtist.png</texture>
+      <keepaspectratio>yes</keepaspectratio>
+      <centered>yes</centered>
+      <align>center</align>
+      <zoom>no</zoom>
+      <valign>top</valign>
+      <visible>!string.equals(#Play.Current.mvArtist,)+!control.isVisible(456852159)+!string.equals(#mvCentral.Play.Started,true)</visible>
+      <animation effect="fade" delay="0" start="0" end="100" time="2000">WindowOpen</animation>
+      <animation effect="fade" delay="5000" start="100" end="0" time="2000" condition="true">conditional</animation>
+    </control>
+
+  </controls>
+</window>

--- a/Common/videoOSD.xml
+++ b/Common/videoOSD.xml
@@ -1,0 +1,949 @@
+<?xml version="1.0" encoding="utf-8" standalone="yes"?>
+<window>
+<id>2901</id>
+<defaultcontrol>995</defaultcontrol>
+<allowoverlay>no</allowoverlay>
+<controls>
+	
+		<control>
+    	<description>background image (not used!)</description>
+      <type>button</type>
+      <id>996</id>
+      <posX>2180</posX>
+      <posY>628</posY>
+      <width>20</width>
+      <height>20</height>
+      <onup>996</onup>
+      <ondown>996</ondown>
+      <onleft>996</onleft>
+      <onright>996</onright>
+    </control>
+    
+ 		<control>
+			<description>Info button DUMMY</description>
+			<posY>888</posY>
+			<posX>-2000</posX>
+			<type>button</type>
+			<id>998</id>
+			<label>-</label>
+			<textureFocus>osd_info_button_focus.png</textureFocus>
+			<textureNoFocus>osd_info_button_nofocus.png</textureNoFocus>
+			<onup>998</onup>
+			<ondown>998</ondown>
+			<onright>218</onright>
+			<onleft>995</onleft>
+			<width>43</width>
+			<height>43</height>
+		</control>
+    
+ 	<!-- CD/DVD Disk Logo -->
+
+ 	<control>
+ 		<description>Movie CDArt</description>
+ 		<type>image</type>
+ 		<id>0</id>
+ 	    <posX>275</posX>
+ 		<posY>600</posY>
+     	<width>300</width>
+ 		<height>300</height>
+		<texture>#fanarthandler.movie.cd.selected</texture>
+ 		<keepaspectratio>yes</keepaspectratio>
+ 		<centered>yes</centered>
+   		<align>center</align>
+ 		<zoom>no</zoom>
+ 		<valign>top</valign>
+ 		<visible>!string.equals(#Play.Current.IMDBNumber,)</visible>
+        <animation effect="rotate" delay="0" end="-360" time="8000" loop="true" condition="!player.paused">Conditional</animation>
+		<animation effect="fade" time="500">VisibleChange</animation>
+ 	</control>
+
+ 	<control>
+ 		<description>Series Seasons CDArt</description>
+ 		<type>image</type>
+ 		<id>234832</id>
+ 	    <posX>275</posX>
+ 		<posY>600</posY>
+     	<width>300</width>
+ 		<height>300</height>
+ 		<texture>#TVSeries.Play.CDSeason</texture>
+ 		<keepaspectratio>yes</keepaspectratio>
+ 		<centered>yes</centered>
+   		<align>center</align>
+ 		<zoom>no</zoom>
+ 		<valign>top</valign>
+ 		<visible>!string.equals(#TVSeries.Episode.SeriesName,)</visible>
+        <animation effect="rotate" delay="0" end="-360" time="8000" loop="true" condition="!player.paused">Conditional</animation>
+		<animation effect="fade" time="500">VisibleChange</animation>
+ 	</control>
+
+	<control>
+ 		<description>Series CDArt</description>
+ 		<type>image</type>
+ 		<id>0</id>
+ 	    <posX>275</posX>
+ 		<posY>600</posY>
+     	<width>300</width>
+ 		<height>300</height>
+ 		<texture>#TVSeries.Play.CD</texture>
+ 		<keepaspectratio>yes</keepaspectratio>
+ 		<centered>yes</centered>
+   		<align>center</align>
+ 		<zoom>no</zoom>
+ 		<valign>top</valign>
+ 		<visible>!string.equals(#TVSeries.Episode.SeriesName,)+!control.hasthumb(234832)</visible>
+        <animation effect="rotate" delay="0" end="-360" time="8000" loop="true" condition="!player.paused">Conditional</animation>
+		<animation effect="fade" time="500">VisibleChange</animation>
+ 	</control>
+
+ 	<control>
+ 		<description>mvCentral CDArt</description>
+ 		<type>image</type>
+ 		<id>0</id>
+ 	    <posX>275</posX>
+ 		<posY>600</posY>
+     	<width>300</width>
+ 		<height>300</height>
+		<texture>..\..\..\Thumbs\CDArt\Music\#Play.Current.mvArtist - #Play.Current.mvAlbum.png</texture>
+ 		<keepaspectratio>yes</keepaspectratio>
+ 		<centered>yes</centered>
+   		<align>center</align>
+ 		<zoom>no</zoom>
+ 		<valign>top</valign>
+ 		<visible>!string.equals(#Play.Current.mvArtist,)</visible>
+        <animation effect="rotate" delay="0" end="-360" time="8000" loop="true" condition="!player.paused">Conditional</animation>
+		<animation effect="fade" time="500">VisibleChange</animation>
+ 	</control>
+
+ 	<!-- -->
+
+		<control>
+			<description>background top</description>
+			<type>image</type>
+			<id>0</id>
+    	<posX>183</posX>
+    	<posY>706</posY>
+    	<width>1553</width>
+    	<height>352</height>
+    	<texture>osd_bg.png</texture>
+		</control>
+    	
+    <control>
+    	<description>clock bg</description>
+    	<type>image</type>
+    	<id>0</id>
+    	<posX>1481</posX>
+    	<posY>779</posY>
+    	<width>187</width>
+    	<height>88</height>
+    	<texture>osd_clock_bg.png</texture>
+    </control>
+
+		<control>
+			<description>Movie thumb</description>
+			<type>image</type>
+			<id>102</id>
+    	<posX>275</posX>
+    	<posY>765</posY>
+    	<width>166</width>
+    	<height>242</height>
+			<texture>#Play.Current.Thumb</texture>
+			<keepaspectratio>yes</keepaspectratio>
+			<centered>yes</centered>
+      <align>center</align>
+			<zoom>no</zoom>
+			<valign>top</valign>
+		</control>
+
+		<control>
+			<description>Music thumb</description>
+			<type>image</type>
+			<id>0</id>
+    	<posX>275</posX>
+    	<posY>765</posY>
+    	<width>166</width>
+    	<height>242</height>
+			<texture>#fanarthandler.music.artisthumb.play</texture>
+			<keepaspectratio>yes</keepaspectratio>
+			<centered>yes</centered>
+      <align>center</align>
+			<zoom>no</zoom>
+			<valign>top</valign>
+			<visible>!control.hasthumb(102)</visible>
+		</control>
+
+	<!-- Clear Art/Logo -->
+
+ 	<control>
+ 		<description>Series ClearArt</description>
+ 		<type>image</type>
+ 		<id>159357</id>
+ 	    <posX>1430</posX>
+ 		<posY>600</posY>
+     	<width>250</width>
+ 		<height>140</height>
+ 		<texture>#fanarthandler.tvseries.clearart.selected</texture>
+ 		<keepaspectratio>yes</keepaspectratio>
+ 		<centered>yes</centered>
+   		<align>center</align>
+ 		<zoom>no</zoom>
+ 		<valign>top</valign>
+ 		<visible>!string.equals(#TVSeries.Episode.SeriesName,)</visible>
+		<animation effect="fade" time="500">VisibleChange</animation>
+        <animation effect="fade" time="250">WindowOpen</animation>
+        <animation effect="fade" time="250">WindowClose</animation>
+ 	</control>
+
+ 	<control>
+ 		<description>Series ClearLogo</description>
+ 		<type>image</type>
+ 		<id>0</id>
+ 	    <posX>1430</posX>
+ 		<posY>600</posY>
+     	<width>250</width>
+ 		<height>140</height>
+ 		<texture>#fanarthandler.tvseries.clearlogo.selected</texture>
+ 		<keepaspectratio>yes</keepaspectratio>
+ 		<centered>yes</centered>
+   		<align>center</align>
+ 		<zoom>no</zoom>
+ 		<valign>top</valign>
+ 		<visible>!string.equals(#TVSeries.Episode.SeriesName,)+!control.hasthumb(159357)</visible>
+		<animation effect="fade" time="500">VisibleChange</animation>
+        <animation effect="fade" time="250">WindowOpen</animation>
+        <animation effect="fade" time="250">WindowClose</animation>
+ 	</control>
+
+ 	<control>
+ 		<description>Movie ClearArt</description>
+ 		<type>image</type>
+ 		<id>753951</id>
+ 	    <posX>1430</posX>
+ 		<posY>600</posY>
+     	<width>250</width>
+ 		<height>140</height>
+		<texture>#fanarthandler.movie.clearart.selected</texture>
+ 		<keepaspectratio>yes</keepaspectratio>
+ 		<centered>yes</centered>
+   		<align>center</align>
+ 		<zoom>no</zoom>
+ 		<valign>top</valign>
+ 		<visible>!string.equals(#Play.Current.IMDBNumber,)</visible>
+		<animation effect="fade" time="500">VisibleChange</animation>
+        <animation effect="fade" time="250">WindowOpen</animation>
+        <animation effect="fade" time="250">WindowClose</animation>
+ 	</control>
+
+ 	<control>
+ 		<description>Movie ClearLogo</description>
+ 		<type>image</type>
+ 		<id>0</id>
+ 	    <posX>1430</posX>
+ 		<posY>600</posY>
+     	<width>250</width>
+ 		<height>140</height>
+		<texture>#fanarthandler.movie.clearlogo.selected</texture>
+ 		<keepaspectratio>yes</keepaspectratio>
+ 		<centered>yes</centered>
+   		<align>center</align>
+ 		<zoom>no</zoom>
+ 		<valign>top</valign>
+ 		<visible>!string.equals(#Play.Current.IMDBNumber,)+!control.hasthumb(753951)</visible>
+		<animation effect="fade" time="500">VisibleChange</animation>
+        <animation effect="fade" time="250">WindowOpen</animation>
+        <animation effect="fade" time="250">WindowClose</animation>
+ 	</control>
+
+ 	<control>
+ 		<description>mvCentral ClearArt</description>
+ 		<type>image</type>
+ 		<id>357951</id>
+ 	    <posX>1455</posX>
+ 		<posY>650</posY>
+     	<width>200</width>
+ 		<height>75</height>
+		<texture>..\..\..\Thumbs\ClearArt\Music\#Play.Current.mvArtist.png</texture>
+ 		<keepaspectratio>yes</keepaspectratio>
+ 		<centered>yes</centered>
+   		<align>center</align>
+ 		<zoom>no</zoom>
+ 		<valign>bottom</valign>
+ 		<visible>!string.equals(#Play.Current.mvArtist,)</visible>
+		<animation effect="fade" time="500">VisibleChange</animation>
+        <animation effect="fade" time="250">WindowOpen</animation>
+        <animation effect="fade" time="250">WindowClose</animation>
+ 	</control>
+ 	
+    <control>
+        <description>Music ClearArt</description>
+        <type>image</type>
+        <id>456852</id>
+ 	    <posX>1455</posX>
+ 		<posY>650</posY>
+     	<width>200</width>
+ 		<height>75</height>
+        <texture>#fanarthandler.music.artistclearart.play</texture>
+ 		<keepaspectratio>yes</keepaspectratio>
+ 		<centered>yes</centered>
+   		<align>center</align>
+ 		<zoom>no</zoom>
+ 		<valign>bottom</valign>
+ 		<visible>!control.hasthumb(357951)+!string.equals(#Play.Current.mvArtist,)</visible>
+		<animation effect="fade" time="500">VisibleChange</animation>
+        <animation effect="fade" time="250">WindowOpen</animation>
+        <animation effect="fade" time="250">WindowClose</animation>
+    </control>
+
+ 	<control>
+ 		<description>mvCentral ClearLogo</description>
+ 		<type>image</type>
+ 		<id>0</id>
+ 	    <posX>1430</posX>
+ 		<posY>600</posY>
+     	<width>250</width>
+ 		<height>140</height>
+		<texture>..\..\..\Thumbs\ClearLogo\Music\#Play.Current.mvArtist.png</texture>
+ 		<keepaspectratio>yes</keepaspectratio>
+ 		<centered>yes</centered>
+   		<align>center</align>
+ 		<zoom>no</zoom>
+ 		<valign>bottom</valign>
+ 		<visible>!control.hasthumb(357951)+!control.hasthumb(456852)+!string.equals(#Play.Current.mvArtist,)</visible>
+		<animation effect="fade" time="500">VisibleChange</animation>
+        <animation effect="fade" time="250">WindowOpen</animation>
+        <animation effect="fade" time="250">WindowClose</animation>
+ 	</control>
+
+ 	<!-- -->
+
+		<control>
+			<description>Movie Name</description>
+			<id>36</id>
+    	<type>fadelabel</type>
+    	<width>925</width>
+    	<height>24</height>
+    	<posX>484</posX>
+    	<posY>774</posY>
+    	<font>fontB20</font>
+    	<label>#Play.Current.Title</label>
+		</control>
+
+		<control>
+			<description>Year/Genre Info</description>
+			<id>0</id>
+    	<type>fadelabel</type>
+    	<width>940</width>
+    	<posX>484</posX>
+    	<posY>835</posY>
+    	<font>TitanLight14</font>
+    	<textcolor>ff6b6b6b</textcolor>
+			<label>#Play.Current.Genre - #Play.Current.Year</label>
+		<visible>!string.equals(#mvCentral.isPlaying,true)</visible>
+		</control>
+
+		<control>
+			<description>mvCentral Artist/Album/Year/Genre Info</description>
+			<id>0</id>
+    		<type>fadelabel</type>
+	    	<width>940</width>
+    		<posX>484</posX>
+	    	<posY>835</posY>
+	    	<font>TitanLight14</font>
+	    	<textcolor>ff6b6b6b</textcolor>
+			<label>#Play.Current.mvArtist#(iif(eq(#Play.Current.mvAlbum,''),'',string.format(' - {0}',#Play.Current.mvAlbum)))#(iif(eq(#Play.Current.Year,''),'',string.format(' ({0})',#Play.Current.Year)))#(iif(eq(#Play.Current.Genre,''),'',string.format(' - {0}',#Play.Current.Genre)))</label>
+			<visible>string.equals(#mvCentral.isPlaying,true)</visible>
+		</control>
+
+    <control>
+    	<type>label</type>
+    	<id>1</id>
+    	<description>Clock</description>
+    	<posX>1500</posX>
+    	<posY>828</posY>
+    	<width>144</width>
+    	<font>TitanLight14</font>
+    	<align>center</align>
+    	<label>#time</label>
+    	<textcolor>ff00b7ff</textcolor>
+    </control>
+
+
+    <control>
+    	<description>pause button</description>
+    	<type>image</type>
+    	<id>1</id>
+    	<posX>856</posX>
+    	<posY>295</posY>
+    	<width>209</width>
+    	<height>221</height>
+    	<texture>osd_pause.png</texture>
+      <visible>player.paused</visible>
+		<animation effect="fade" time="500">VisibleChange</animation>
+    </control>
+
+		<control>
+			<description>Plot</description>
+			<type>textboxscrollup</type>
+			<id>1</id>
+    	<posX>497</posX>
+    	<posY>168</posY>
+    	<width>1120</width>
+    	<height>500</height>
+    	<font>TitanLight16</font>
+    	<textcolor>ff393939</textcolor>
+			<label>#Play.Current.Plot</label>
+			<seperator>--------------------------------------------------------------------------------------------------------------------------------------------------------------</seperator>
+			<visible>Control.HasFocus(998)</visible>
+		</control>
+
+    <control>
+    	<description>progressbar bg</description>
+    	<type>image</type>
+    	<id>104</id>
+    	<posX>588</posX>
+    	<posY>906</posY>
+    	<width>737</width>
+    	<height>19</height>
+    	<texture>osd_progress_bg.png</texture>
+    </control>
+
+
+
+
+		<control>
+			<description>Remaining time</description>
+			<type>label</type>
+			<id>102</id>
+    	<posX>1435</posX>
+    	<posY>899</posY>
+    	<label>#currentremaining</label>
+    	<align>right</align>
+    	<font>font11</font>
+      <textcolor>ff00b7ff</textcolor>
+		</control>
+
+		<control>
+			<description>Start Time Info</description>
+			<type>label</type>
+			<id>101</id>
+    	<posX>484</posX>
+    	<posY>899</posY>
+    	<label>#currentplaytime</label>
+    	<align>left</align>
+    	<font>font11</font>
+      <textcolor>ff00b7ff</textcolor>
+		</control>
+	
+		<include>videoOSD.mediainfo.xml</include>
+		
+		<control>
+			<description>Info bg</description>
+			<type>image</type>
+			<id>0</id>
+			<posX>165</posX>
+			<posY>21</posY>
+			<width>1590</width>
+			<height>764</height>
+			<texture>osd_top_bg.png</texture>
+			<visible>Control.HasFocus(998)</visible>
+		</control>
+	
+ 		<control>
+			<description>osd logo info</description>
+			<type>image</type>
+			<id>0</id>
+			<posX>257</posX>
+			<posY>169</posY>
+			<width>187</width>
+			<height>127</height>
+			<texture>osd_logo_info.png</texture>
+			<visible>Control.HasFocus(998)</visible>
+		</control>
+    
+ 		<control>
+			<description>Settings bg</description>
+			<type>image</type>
+			<id>0</id>
+			<posX>165</posX>
+			<posY>383</posY>
+			<width>1590</width>
+			<height>402</height>
+			<texture>osd_top_bg_settings.png</texture>
+			<visible>Control.IsVisible(501) | Control.IsVisible(801) | Control.IsVisible(750)</visible>
+		</control>	
+		
+	  <control>
+			<description>Subtitles Menu</description>
+			<type>checkbutton</type>
+			<id>218</id>
+			<posY>888</posY>
+			<posX>1555</posX>
+			<width>47</width>
+			<height>47</height>
+      <markHeight>47</markHeight>
+      <markWidth>47</markWidth>
+      <markalign>left</markalign>
+      <markXOff>0</markXOff>
+      <markYOff>0</markYOff>
+      <textureFocus>osd_sub_button_focus.png</textureFocus>
+      <textureNoFocus>osd_sub_button_nofocus.png</textureNoFocus>
+      <textureCheckmark>osd_sub_button_focus.png</textureCheckmark>
+      <textureCheckmarkNoFocus>osd_sub_button_nofocus.png</textureCheckmarkNoFocus> 
+			<label>-</label>
+			<font>-</font>
+			<onleft>995</onleft>
+			<onright>221</onright>
+			<onup>218</onup>
+			<ondown>218</ondown>
+	  </control>
+		
+		<control>
+			<description>Audio Menu</description>
+			<type>checkbutton</type>
+			<id>221</id>
+			<posY>887</posY>
+			<posX>1618</posX>
+			<width>47</width>
+			<height>47</height>
+			<onleft>218</onleft>
+			<onright>995</onright>
+			<ondown>221</ondown>
+			<onup>221</onup>
+      <markHeight>47</markHeight>
+      <markWidth>47</markWidth>
+      <markalign>left</markalign>
+      <markXOff>0</markXOff>
+      <markYOff>0</markYOff>
+      <textureFocus>osd_audio_button_focus.png</textureFocus>
+      <textureNoFocus>osd_audio_button_nofocus.png</textureNoFocus>
+      <textureCheckmark>osd_audio_button_focus.png</textureCheckmark>
+      <textureCheckmarkNoFocus>osd_audio_button_nofocus.png</textureCheckmarkNoFocus> 
+			<label>-</label>
+			<font>-</font>
+	  </control>
+	   
+		<control>
+	  	<description>Video Menu</description>
+	    <type>checkbutton</type>
+	    <id>220</id>
+			<posY>888</posY>
+			<posX>-2000</posX>
+			<width>47</width>
+			<height>47</height>
+      <markHeight>47</markHeight>
+      <markWidth>47</markWidth>
+      <markalign>left</markalign>
+      <markXOff>0</markXOff>
+      <markYOff>0</markYOff>
+      <textureFocus>osd_video_button_focus.png</textureFocus>
+      <textureNoFocus>osd_video_button_nofocus.png</textureNoFocus>
+      <textureCheckmark>osd_video_button_focus.png</textureCheckmark>
+      <textureCheckmarkNoFocus>osd_video_button_nofocus.png</textureCheckmarkNoFocus> 
+	    <label>-</label>
+	    <font>-</font>
+	    <onleft>995</onleft>
+	    <onright>221</onright>
+	    <onup>220</onup>
+	    <ondown>220</ondown>
+		</control>
+	
+		<control>
+			<description>Info button</description>
+			<posY>887</posY>
+			<posX>1498</posX>
+			<type>button</type>
+			<id>995</id>
+			<label>-</label>
+			<textureFocus>osd_info_button_focus.png</textureFocus>
+			<textureNoFocus>osd_info_button_nofocus.png</textureNoFocus>
+			<onup>995</onup>
+			<ondown>995</ondown>
+			<onright>218</onright>
+			<onclick>#(skin.setfocus(2901,998))</onclick>
+			<onleft>221</onleft>
+      <width>32</width>
+      <height>48</height>
+		</control>
+		
+	  <control>
+	    <description>Sub Menu Background (subtitles)</description>
+	    <type>image</type>
+	    <id>302</id>
+	    <posX>20</posX>
+	    <posY>-2000</posY>
+	    <width>223</width>
+	    <height>219</height>
+	    <texture>-</texture>
+	    <visible>no</visible>
+	  </control>
+		
+ 		<control>
+			<description>settings label bg</description>
+			<type>image</type>
+			<id>0</id>
+			<posX>856</posX>
+			<posY>485</posY>
+			<width>738</width>
+			<height>58</height>
+			<texture>osd_settings_label_bg.png</texture>
+			<visible>Control.IsVisible(801) | Control.IsVisible(500)</visible>
+		</control>
+      
+	  <control>
+	    <description>Bookmarks Menu</description>
+	    <type>checkbutton</type>
+	    <id>219</id>
+	    <posX>-2000</posX>
+	    <posY>537</posY>
+	    <width>62</width>
+	    <height>43</height>
+      <textureFocus>-</textureFocus>
+      <textureNoFocus>-</textureNoFocus>
+      <textureCheckmark>-</textureCheckmark>
+      <textureCheckmarkNoFocus>-</textureCheckmarkNoFocus>
+	    <label>-</label>
+	    <font>-</font>
+	    <onleft>213</onleft>
+	    <onright>218</onright>
+	    <onup>215</onup>
+	    <ondown>214</ondown>
+	    <visible>no</visible>
+	  </control>
+		
+	  <control>
+	    <description>Sub Menu Background (volume)</description>
+	    <type>image</type>
+	    <id>300</id>
+	    <posX>782</posX>
+	    <posY>-2000</posY>
+	    <width>462</width>
+	    <height>287</height>
+	    <texture>-</texture>
+	    <visible>no</visible>
+	  </control>
+		
+	  <control>
+	    <description>Sub Menu Background (subtitles)</description>
+	    <type>image</type>
+	    <id>302</id>
+	    <posX>782</posX>
+	    <posY>-2000</posY>
+	    <width>462</width>
+	    <height>287</height>
+	    <texture>-</texture>
+	    <visible>no</visible>
+	  </control>
+		
+	  <control>
+	    <description>Sub Menu Background (bookmarks)</description>
+	    <type>image</type>
+	    <id>303</id>
+	    <posX>782</posX>
+	    <posY>-2000</posY>
+	    <width>462</width>
+	    <height>287</height>
+	    <texture>-</texture>
+	    <visible>no</visible>
+	  </control>
+		
+	  <control>
+	    <description>Sub Menu Background (video)</description>
+	    <type>image</type>
+	    <id>304</id>
+	    <posX>782</posX>
+	    <posY>-2000</posY>
+	    <width>462</width>
+	    <height>287</height>
+	    <texture>-</texture>
+	    <visible>no</visible>
+	  </control>
+		
+	  <control>
+	    <description>Sub Menu Background (audio)</description>
+	    <type>image</type>
+	    <id>305</id>
+	    <posX>782</posX>
+	    <posY>-2000</posY>
+	    <width>462</width>
+	    <height>287</height>
+	    <texture>-</texture>
+	    <visible>no</visible>
+	  </control>
+		
+	  <control>
+	    <description>Sub Menu Nib</description>
+	    <type>image</type>
+	    <id>350</id>
+	    <texture>-</texture>
+	    <visible>no</visible>
+	  </control>
+		
+    <control>
+      <description>Video Position label</description>
+      <type>label</type>
+      <id>750</id>
+      <posX>399</posX>
+      <posY>464</posY>
+	  	<align>left</align>
+      <label>Video Position</label>
+      <visible>no</visible>
+	  	<font>TitanLight12</font>
+	  	<textcolor>ff393939</textcolor>
+    </control>
+	
+    <control>
+      <description>Video Position Slider</description>
+      <type>slider</type>
+      <id>700</id>
+      <posX>666</posX>
+      <posY>459</posY>
+      <spintype>float</spintype>
+      <showrange>no</showrange>
+      <textureSliderBar>osd_slider_bg.png</textureSliderBar>
+      <textureSliderNib>osd_slider_nibNF.png</textureSliderNib>
+      <textureSliderNibFocus>osd_slider_nibFO.png</textureSliderNibFocus>
+      <onup>703</onup>
+      <ondown>704</ondown>
+      <onleft>700</onleft>
+      <onright>700</onright>
+      <visible>no</visible>
+    </control>
+	
+    <control>
+      <description>Non-Interleaved Checkbox</description>
+      <type>checkmark</type>
+      <id>701</id>
+      <posX>323</posX>
+      <posY>246</posY>
+      <label>306</label>
+      <onup>706</onup>
+      <ondown>702</ondown>
+      <onleft>701</onleft>
+      <onright>701</onright>
+      <visible>no</visible>
+    </control>
+	
+    <control>
+      <description>No Cache Checkbox</description>
+      <type>checkmark</type>
+      <id>702</id>
+      <posX>323</posX>
+      <posY>299</posY>
+      <label>431</label>
+      <onup>701</onup>
+      <ondown>703</ondown>
+      <onleft>702</onleft>
+      <onright>702</onright>
+      <visible>no</visible>
+    </control>
+	
+    <control>
+      <description>Adjust Framerate Checkbox</description>
+      <type>checkmark</type>
+      <id>703</id>
+      <posX>323</posX>
+      <posY>346</posY>
+      <label>343</label>
+      <onup>702</onup>
+      <ondown>700</ondown>
+      <onleft>703</onleft>
+      <onright>703</onright>
+      <visible>no</visible>
+    </control>
+	
+    <control>
+      <description>brightness label</description>
+      <type>label</type>
+      <id>752</id>
+      <posX>399</posX>
+      <posY>519</posY>
+      <label>464</label>
+	  	<font>TitanLight12</font>
+	  	<textcolor>ff393939</textcolor>
+      <visible>no</visible>
+    </control>
+	
+    <control>
+      <description>brightness</description>
+      <type>slider</type>
+      <id>704</id>
+      <posX>666</posX>
+      <posY>514</posY>
+      <spintype>float</spintype>
+      <showrange>no</showrange>
+      <textureSliderBar>osd_slider_bg.png</textureSliderBar>
+      <textureSliderNib>osd_slider_nibNF.png</textureSliderNib>
+      <textureSliderNibFocus>osd_slider_nibFO.png</textureSliderNibFocus>
+      <onup>700</onup>
+      <ondown>705</ondown>
+      <onleft>704</onleft>
+      <onright>704</onright>
+      <visible>no</visible>
+    </control>
+	
+    <control>
+      <description>contrast label</description>
+      <type>label</type>
+      <id>753</id>
+      <posX>399</posX>
+      <posY>579</posY>
+      <label>465</label>
+	  	<font>TitanLight12</font>
+	  	<textcolor>ff393939</textcolor>
+      <visible>no</visible>
+    </control>
+	
+    <control>
+      <description>contrast</description>
+      <type>slider</type>
+      <id>705</id>
+      <posX>666</posX>
+      <posY>574</posY>
+      <spintype>float</spintype>
+      <showrange>no</showrange>
+      <textureSliderBar>osd_slider_bg.png</textureSliderBar>
+      <textureSliderNib>osd_slider_nibNF.png</textureSliderNib>
+      <textureSliderNibFocus>osd_slider_nibFO.png</textureSliderNibFocus>
+      <onup>704</onup>
+      <ondown>706</ondown>
+      <onleft>705</onleft>
+      <onright>705</onright>
+      <visible>no</visible>
+    </control>
+	
+    <control>
+      <description>gamma label</description>
+      <type>label</type>
+      <id>754</id>
+      <posX>399</posX>
+      <posY>638</posY>
+      <label>466</label>
+	  	<font>TitanLight12</font>
+	  	<textcolor>ff393939</textcolor>
+      <visible>no</visible>
+    </control>
+	
+    <control>
+      <description>gamma</description>
+      <type>slider</type>
+      <id>706</id>
+      <posX>666</posX>
+      <posY>634</posY>
+      <spintype>float</spintype>
+      <showrange>no</showrange>
+      <textureSliderBar>osd_slider_bg.png</textureSliderBar>
+      <textureSliderNib>osd_slider_nibNF.png</textureSliderNib>
+      <textureSliderNibFocus>osd_slider_nibFO.png</textureSliderNibFocus>
+      <onup>705</onup>
+      <ondown>220</ondown>
+      <onleft>706</onleft>
+      <onright>706</onright>
+      <visible>no</visible>
+    </control>
+	
+    <control>
+      <description>Create Bookmark</description>
+      <type>button</type>
+      <id>600</id>
+      <posX>328</posX>
+      <posY>462</posY>
+      <width>293</width>
+      <textureFocus>button_green_focus_165x32.png</textureFocus>
+      <textureNoFocus>button_green_nofocus_165x32.png</textureNoFocus>
+      <label>294</label>
+      <font>font12</font>
+      <colordiffuse>ffffffff</colordiffuse>
+      <onleft>600</onleft>
+      <onright>602</onright>
+      <onup>600</onup>
+      <ondown>601</ondown>
+      <visible>no</visible>
+    </control>
+	
+    <control>
+      <description>Clear Bookmarks</description>
+      <type>button</type>
+      <id>602</id>
+      <posX>666</posX>
+      <posY>462</posY>
+      <width>293</width>
+      <textureFocus>button_green_focus_165x32.png</textureFocus>
+      <textureNoFocus>button_green_nofocus_165x32.png</textureNoFocus>
+      <label>296</label>
+      <font>font12</font>
+      <colordiffuse>ffffffff</colordiffuse>
+      <onleft>600</onleft>
+      <onright>601</onright>
+      <onup>600</onup>
+      <ondown>601</ondown>
+      <visible>no</visible>
+    </control>
+	
+    <control>
+      <description>Bookmarks List Control</description>
+      <type>listcontrol</type>
+      <id>601</id>
+      <posX>328</posX>
+      <posY>512</posY>
+      <width>631</width>
+      <height>150</height>
+      <onleft>602</onleft>
+      <onright>600</onright>
+      <onup>600</onup>
+      <ondown>601</ondown>
+      <spinPosX>826</spinPosX>
+      <spinPosY>600</spinPosY>
+      <visible>no</visible>
+    </control>
+	
+		<control>
+	      <description>Progress Bar</description>
+		  <type>progress</type>
+		  <id>1</id>
+    	  <posX>578</posX>
+    	  <posY>909</posY>
+    	  <width>758</width>
+    	  <height>15</height>
+    	  <label>#percentage</label>
+    	  <texturebg>-</texturebg>
+    	  <lefttexture>osd_progress_left.png</lefttexture>
+    	  <midtexture>osd_progress_mid.png</midtexture>
+    	  <righttexture>osd_progress_right.png</righttexture>
+          <label>#percentage</label>
+		  <visible>!control.isVisible(111)</visible>
+		</control>	
+	
+	  <control>
+      <description>Progress Bar</description>
+      <type>tvprogress</type>
+      <id>105</id>
+      <posX>590</posX>
+      <posY>909</posY>
+      <width>730</width>
+      <height>13</height>
+      <toptexture>-</toptexture>
+      <TextureOffsetY>0</TextureOffsetY>
+      <bottomtexture>-</bottomtexture>
+      <texturetick>-</texturetick>
+      <lefttexture>osd_progress_left.png</lefttexture>
+      <midtexture>-</midtexture>
+      <righttexture>-</righttexture>
+      <logotexture>-</logotexture>
+      <fillbackgroundtexture>-</fillbackgroundtexture>
+      <fillbgxoff>-3</fillbgxoff>
+      <fillbgyoff>0</fillbgyoff>
+      <filltexture1>osd_progress_mid.png</filltexture1>
+      <filltexture2>osd_progress_mid.png</filltexture2>
+      <filltexture3>osd_progress_mid_orange.png</filltexture3>
+      <markertexture>osd_progress_comskip_marker.png</markertexture>
+      <fillheight>15</fillheight>
+      <label>#percentage</label>
+      <labelmarkerstarts>#jumppoints</labelmarkerstarts>
+      <labelmarkerends>#chapters</labelmarkerends>
+    </control>
+	
+
+    <import>videoOSD.SubtitlesMenu.xml</import>
+    <import>videoOSD.AudioMenu.xml</import>
+
+</controls>
+</window>


### PR DESCRIPTION
posX change for resized aspect ratio icon in movingpictures.mediainfo.xml, movingpictures.mediainfo.details.xml, myvideo.mediainfo.xml and DialogVideoInfo.xml.

videoFullScreen.xml added FH paths for the video fullscreen pause ClearArt.
common.overlay.xml added FH paths for the video playing GUI video spinning CDArt.
videoOSD.xml I am not sure where it comes into play but I updated the values for ClearArt.